### PR TITLE
Tidy HTML

### DIFF
--- a/.tidy-config
+++ b/.tidy-config
@@ -1,0 +1,8 @@
+tidy-mark: false
+write-back: true
+show-body-only: true
+doctype: omit
+indent: true
+wrap: 0
+input-encoding: utf8
+output-encoding: utf8

--- a/source/documentation/code/index.html
+++ b/source/documentation/code/index.html
@@ -60,7 +60,7 @@ breadcrumbs: true
   {% for code in site.data.code %}
     <tr>
       <td>
-        <a href="{{ code.url }}"></a>{{ code.name }}
+        <a href="{{ code.url }}">{{ code.name }}</a>
       </td>
       <td>
         {{ code.description }}

--- a/source/documentation/code/index.html
+++ b/source/documentation/code/index.html
@@ -44,7 +44,7 @@ breadcrumbs: true
 </table>
 <p>
   Looking to try out our API? Here are some code samples to get started with:
-</p>{% for code in site.data.code %} {% endfor %}
+</p>
 <table class='table'>
   <thead>
     <tr>
@@ -57,14 +57,16 @@ breadcrumbs: true
     </tr>
   </thead>
   <tbody>
+  {% for code in site.data.code %}
     <tr>
       <td>
-        <a href="{{%20code.url%20}}"></a>{{ code.name }}
+        <a href="{{ code.url }}"></a>{{ code.name }}
       </td>
       <td>
         {{ code.description }}
       </td>
     </tr>
+  {% endfor %}
   </tbody>
 </table>
 <p>

--- a/source/documentation/code/index.html
+++ b/source/documentation/code/index.html
@@ -6,41 +6,67 @@ redirect_from:
   - /documentation/code.html
 breadcrumbs: true
 ---
-                  <h1 class="title">Code written with the PagerDuty API</h1>
-                  <p>PagerDuty has a very active developer community, and we've gathered some of the best tools here to share:</p>
-                  <table class='table table-striped'>
-                    <thead>
-                      <tr>
-                        <th>Type</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td><a href="/documentation/code/libraries">Libraries</a></td>
-                        <td>Libraries in Python, Ruby or JavaScript to get your project started</td>
-                      </tr>
-                      <tr>
-                        <td><a href="/documentation/code/tools">Tools</a></td>
-                        <td>A selection of finished tools for chat integration, reporting or scheduling PagerDuty. Also includes 2-way integrations.</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                  <p>Looking to try out our API? Here are some code samples to get started with:</p>
-                  <table class='table'>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                    {% for code in site.data.code %}
-                      <tr>
-                        <td><a href="{{ code.url }}"</a>{{ code.name }}</td>
-                        <td>{{ code.description }}</td>
-                      </tr>
-                    {% endfor %}
-                    </tbody>
-                  </table>
-                  <p>Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.</p>
+<h1 class="title">
+  Code written with the PagerDuty API
+</h1>
+<p>
+  PagerDuty has a very active developer community, and we've gathered some of the best tools here to share:
+</p>
+<table class='table table-striped'>
+  <thead>
+    <tr>
+      <th>
+        Type
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="/documentation/code/libraries">Libraries</a>
+      </td>
+      <td>
+        Libraries in Python, Ruby or JavaScript to get your project started
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <a href="/documentation/code/tools">Tools</a>
+      </td>
+      <td>
+        A selection of finished tools for chat integration, reporting or scheduling PagerDuty. Also includes 2-way integrations.
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  Looking to try out our API? Here are some code samples to get started with:
+</p>{% for code in site.data.code %} {% endfor %}
+<table class='table'>
+  <thead>
+    <tr>
+      <th>
+        Name
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <a href="{{%20code.url%20}}"></a>{{ code.name }}
+      </td>
+      <td>
+        {{ code.description }}
+      </td>
+    </tr>
+  </tbody>
+</table>
+<p>
+  Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.
+</p>

--- a/source/documentation/code/libraries.html
+++ b/source/documentation/code/libraries.html
@@ -14,7 +14,7 @@ nav:
 </h1>
 <p>
   A number of our users have contributed open source libraries:
-</p>{% for library in site.data.libraries %} {% endfor %}
+</p>
 <table class='table table-striped'>
   <thead>
     <tr>
@@ -29,17 +29,21 @@ nav:
       </th>
     </tr>
   </thead>
-  <tr>
-    <td>
-      <a href="{{%20library.url%20}}"></a>{{ library.name }}
-    </td>
-    <td>
-      {{ library.language }}
-    </td>
-    <td>
-      {{ library.description }}
-    </td>
-  </tr>
+  <tbody>
+  {% for library in site.data.libraries %}
+    <tr>
+      <td>
+        <a href="{{ library.url }}"></a>{{ library.name }}
+      </td>
+      <td>
+        {{ library.language }}
+      </td>
+      <td>
+        {{ library.description }}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
 </table>
 <p>
   Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.

--- a/source/documentation/code/libraries.html
+++ b/source/documentation/code/libraries.html
@@ -9,22 +9,38 @@ nav:
   - title: Code
     url: /documentation/code/
 ---
-                    <h1 class="title">PagerDuty API Libraries</h1>
-                    <p>A number of our users have contributed open source libraries:</p>
-                    <table class='table table-striped'>
-                      <thead>
-                        <tr>
-                          <th>Name</th>
-                          <th>Language</th>
-                          <th>Description</th>
-                        </tr>
-                      </thead>
-                      {% for library in site.data.libraries %}
-                        <tr>
-                          <td><a href="{{ library.url }}"</a>{{ library.name }}</td>
-                          <td>{{ library.language }}</td>
-                          <td>{{ library.description }}</td>
-                        </tr>
-                      {% endfor %}
-                    </table>
-                    <p>Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.</p>
+<h1 class="title">
+  PagerDuty API Libraries
+</h1>
+<p>
+  A number of our users have contributed open source libraries:
+</p>{% for library in site.data.libraries %} {% endfor %}
+<table class='table table-striped'>
+  <thead>
+    <tr>
+      <th>
+        Name
+      </th>
+      <th>
+        Language
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tr>
+    <td>
+      <a href="{{%20library.url%20}}"></a>{{ library.name }}
+    </td>
+    <td>
+      {{ library.language }}
+    </td>
+    <td>
+      {{ library.description }}
+    </td>
+  </tr>
+</table>
+<p>
+  Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.
+</p>

--- a/source/documentation/code/libraries.html
+++ b/source/documentation/code/libraries.html
@@ -33,7 +33,7 @@ nav:
   {% for library in site.data.libraries %}
     <tr>
       <td>
-        <a href="{{ library.url }}"></a>{{ library.name }}
+        <a href="{{ library.url }}">{{ library.name }}</a>
       </td>
       <td>
         {{ library.language }}

--- a/source/documentation/code/tools.html
+++ b/source/documentation/code/tools.html
@@ -9,45 +9,70 @@ nav:
   - title: Code
     url: /documentation/code/
 ---
-                  <h1 class="title">PagerDuty API-based Tools</h1>
-                  <p>A number of our users have built tools on top of PagerDuty:</p>
-                  <table class='table table-striped'>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                {% assign tool_type = site.data.tools | sort: "type" %}
-                {% for tool in tool_type %}
-                  {% if tool.tag == 'Tool' %}
-                    <tr>
-                      <td><a href="{{ tool.url }}"</a>{{ tool.name }}</td>
-                      <td>{{ tool.type }}</td>
-                      <td>{{ tool.description }}</td>
-                    </tr>
-                  {% endif %}
-                {% endfor %}
-                  </table>
-                  <h2>Toys</h2>
-                  <p>And here are some more fun things that people have built with our API:</p>
-                  <table class='table table-striped'>
-                    <thead>
-                      <tr>
-                        <th>Name</th>
-                        <th>Type</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                {% for tool in site.data.tools %}
-                  {% if tool.tag == 'Toy' %}
-                    <tr>
-                      <td><a href="{{ tool.url }}"</a>{{ tool.name }}</td>
-                      <td>{{ tool.type }}</td>
-                      <td>{{ tool.description }}</td>
-                    </tr>
-                  {% endif %}
-                {% endfor %}
-                  </table>
-                  <p>Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.</p>
+<h1 class="title">
+  PagerDuty API-based Tools
+</h1>
+<p>
+  A number of our users have built tools on top of PagerDuty:
+</p>{% assign tool_type = site.data.tools | sort: "type" %} {% for tool in tool_type %} {% if tool.tag == 'Tool' %} {% endif %} {% endfor %}
+<table class='table table-striped'>
+  <thead>
+    <tr>
+      <th>
+        Name
+      </th>
+      <th>
+        Type
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tr>
+    <td>
+      <a href="{{%20tool.url%20}}"></a>{{ tool.name }}
+    </td>
+    <td>
+      {{ tool.type }}
+    </td>
+    <td>
+      {{ tool.description }}
+    </td>
+  </tr>
+</table>
+<h2>
+  Toys
+</h2>
+<p>
+  And here are some more fun things that people have built with our API:
+</p>{% for tool in site.data.tools %} {% if tool.tag == 'Toy' %} {% endif %} {% endfor %}
+<table class='table table-striped'>
+  <thead>
+    <tr>
+      <th>
+        Name
+      </th>
+      <th>
+        Type
+      </th>
+      <th>
+        Description
+      </th>
+    </tr>
+  </thead>
+  <tr>
+    <td>
+      <a href="{{%20tool.url%20}}"></a>{{ tool.name }}
+    </td>
+    <td>
+      {{ tool.type }}
+    </td>
+    <td>
+      {{ tool.description }}
+    </td>
+  </tr>
+</table>
+<p>
+  Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.
+</p>

--- a/source/documentation/code/tools.html
+++ b/source/documentation/code/tools.html
@@ -34,7 +34,7 @@ nav:
   {% for tool in tool_type %} {% if tool.tag == 'Tool' %}
     <tr>
       <td>
-        <a href="{{ tool.url }}"></a>{{ tool.name }}
+        <a href="{{ tool.url }}">{{ tool.name }}</a>
       </td>
       <td>
         {{ tool.type }}
@@ -70,7 +70,7 @@ nav:
   {% for tool in site.data.tools %} {% if tool.tag == 'Toy' %}
     <tr>
       <td>
-        <a href="{{ tool.url }}"></a>{{ tool.name }}
+        <a href="{{ tool.url }}">{{ tool.name }}</a>
       </td>
       <td>
         {{ tool.type }}

--- a/source/documentation/code/tools.html
+++ b/source/documentation/code/tools.html
@@ -14,7 +14,8 @@ nav:
 </h1>
 <p>
   A number of our users have built tools on top of PagerDuty:
-</p>{% assign tool_type = site.data.tools | sort: "type" %} {% for tool in tool_type %} {% if tool.tag == 'Tool' %} {% endif %} {% endfor %}
+</p>
+{% assign tool_type = site.data.tools | sort: "type" %}
 <table class='table table-striped'>
   <thead>
     <tr>
@@ -29,24 +30,28 @@ nav:
       </th>
     </tr>
   </thead>
-  <tr>
-    <td>
-      <a href="{{%20tool.url%20}}"></a>{{ tool.name }}
-    </td>
-    <td>
-      {{ tool.type }}
-    </td>
-    <td>
-      {{ tool.description }}
-    </td>
-  </tr>
+  <tbody>
+  {% for tool in tool_type %} {% if tool.tag == 'Tool' %}
+    <tr>
+      <td>
+        <a href="{{ tool.url }}"></a>{{ tool.name }}
+      </td>
+      <td>
+        {{ tool.type }}
+      </td>
+      <td>
+        {{ tool.description }}
+      </td>
+    </tr>
+  {% endif %} {% endfor %}
+  </tbody>
 </table>
 <h2>
   Toys
 </h2>
 <p>
   And here are some more fun things that people have built with our API:
-</p>{% for tool in site.data.tools %} {% if tool.tag == 'Toy' %} {% endif %} {% endfor %}
+</p>
 <table class='table table-striped'>
   <thead>
     <tr>
@@ -61,17 +66,21 @@ nav:
       </th>
     </tr>
   </thead>
-  <tr>
-    <td>
-      <a href="{{%20tool.url%20}}"></a>{{ tool.name }}
-    </td>
-    <td>
-      {{ tool.type }}
-    </td>
-    <td>
-      {{ tool.description }}
-    </td>
-  </tr>
+  <tbody>
+  {% for tool in site.data.tools %} {% if tool.tag == 'Toy' %}
+    <tr>
+      <td>
+        <a href="{{ tool.url }}"></a>{{ tool.name }}
+      </td>
+      <td>
+        {{ tool.type }}
+      </td>
+      <td>
+        {{ tool.description }}
+      </td>
+    </tr>
+  {% endif %} {% endfor %}
+  </tbody>
 </table>
 <p>
   Please review the <a href='/documentation/code/disclaimer'>Disclaimer</a> prior to downloading sample code.

--- a/source/documentation/howto/integration-tutorial.html
+++ b/source/documentation/howto/integration-tutorial.html
@@ -3,21 +3,49 @@ title: Integrating your Monitoring Tool with PagerDuty
 layout: main
 permalink: /documentation/howto/integration-tutorial/
 ---
-                  <h1 class="title">Integrating your Monitoring Tool with PagerDuty</h1>
-                  <p>Thank you for your interest in integrating your monitoring tool with PagerDuty! This guide will introduce you to the various ways our partners and customers create new monitoring tool integrations with PagerDuty.</p>
-                  <p><strong>There are four ways to send incidents to PagerDuty:</strong></p>
-                  <ul>
-                    <li><strong>Best:</strong> <a href="https://www.pagerduty.com/docs/guides/pagerduty-connect/">PD Connect</a> + <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>, a streamlined integration workflow allowing your users to easily integrate their accounts on your service with their PagerDuty accounts.</li>
-                    <li><strong>Good:</strong> <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a> only.</li>
-                    <li><strong>Good:</strong> <a href="https://www.pagerduty.com/docs/guides/agent-install-guide/">PD Agent</a>. PD Agent includes command-line tools to accept events from your monitoring tool to PagerDuty and a daemon process that handles the sending of these events to PagerDuty. This is generally used for on-premise monitoring tools (such as Nagios and Icinga) that have the ability to use command-line tools.</li>
-                    <li><strong>Okay:</strong> <a href="https://www.pagerduty.com/docs/guides/email-integration-guide/">Email-based integrations</a>. Note that while we fully support email-based integrations, they lack the security and real-time acknowledgement available with our <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>. Most of our customers do not consider email-based integrations to be “real” integrations and will ask for something better.</li>
-                  </ul>
-                  <p><strong>If you are integrating a proprietary, in-house monitoring tool with PagerDuty</strong>, we recommending using the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>. You can also use the <a href="https://www.pagerduty.com/docs/guides/agent-install-guide/">PD Agent</a>.</p>
-                  <p><strong>If your monitoring tool will be used by other companies</strong>, we recommend implementing <a href="https://www.pagerduty.com/docs/guides/pagerduty-connect/">PD Connect</a> and the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a> to provide a one-click integration for your customers. We also strongly recommend that you write an integration guide (with screenshots) that walks your customers through the process on both your application and PagerDuty. If you do so, we will host your integration guide on our site, add your company to our Partners page, and provide a complementary single-user PagerDuty account for your ongoing integration testing needs.</p>
-                  <p><strong>If it’s relevant to your application, we strongly recommend creating a bi-directional integration.</strong> We’ve found our customers have come to expect their monitoring and incident management tools to remain in sync. PagerDuty can send incident updates (e.g., acknowledge/resolve) to your application in two different ways:</p>
-                  <ul>
-                    <li><strong>Best:</strong> <a href="https://developer.pagerduty.com/documentation/rest/webhooks">Webhooks</a>. PagerDuty can automatically send HTTP callbacks whenever an incident is triggered, acknowledged, unacknowledged (due to timeout), resolved, reassigned, escalated, or delegated. Webhooks are specific to a Service. This is the preferred method for SaaS-based monitoring tools.</li>
-                    <li><strong>Okay:</strong> Regularly poll the <a href="https://developer.pagerduty.com/documentation/rest/incidents">Incidents API</a> for <a href="https://developer.pagerduty.com/documentation/rest/incidents/show">details about incidents</a> you’ve sent over. Webhooks are preferable because the <a href="https://developer.pagerduty.com/documentation/rest/incidents">Incidents API</a> requires an additional, distinct <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> and polling isn’t fun for anyone. This is only option for those running software behind an impenetrable firewall.</li>
-                  </ul>
-                  <p><strong>If your monitoring tool has the notion of maintenance windows</strong>, you may want to develop an integration with our <a href="https://developer.pagerduty.com/documentation/rest/maintenance_windows">Maintenance Windows API</a> to keep the maintenance windows between your application and PagerDuty in sync. A bi-directional integration will require polling, but a longer interval should work relatively well. Note: this API requires the use of a <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> (distinct from the "Service Key" used by the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>).</p>
-                  <p><strong>If your monitoring tool has the notion of notes</strong>, you can also <a href="https://developer.pagerduty.com/documentation/rest/incidents/notes/list">read</a> and <a href="https://developer.pagerduty.com/documentation/rest/incidents/notes/create">add</a> notes to incidents. A bi-directional integration will require polling. Note: this API requires the use of a <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> (distinct from the “Service Key” used by the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>).</p>
+<h1 class="title">
+  Integrating your Monitoring Tool with PagerDuty
+</h1>
+<p>
+  Thank you for your interest in integrating your monitoring tool with PagerDuty! This guide will introduce you to the various ways our partners and customers create new monitoring tool integrations with PagerDuty.
+</p>
+<p>
+  <strong>There are four ways to send incidents to PagerDuty:</strong>
+</p>
+<ul>
+  <li>
+    <strong>Best:</strong> <a href="https://www.pagerduty.com/docs/guides/pagerduty-connect/">PD Connect</a> + <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>, a streamlined integration workflow allowing your users to easily integrate their accounts on your service with their PagerDuty accounts.
+  </li>
+  <li>
+    <strong>Good:</strong> <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a> only.
+  </li>
+  <li>
+    <strong>Good:</strong> <a href="https://www.pagerduty.com/docs/guides/agent-install-guide/">PD Agent</a>. PD Agent includes command-line tools to accept events from your monitoring tool to PagerDuty and a daemon process that handles the sending of these events to PagerDuty. This is generally used for on-premise monitoring tools (such as Nagios and Icinga) that have the ability to use command-line tools.
+  </li>
+  <li>
+    <strong>Okay:</strong> <a href="https://www.pagerduty.com/docs/guides/email-integration-guide/">Email-based integrations</a>. Note that while we fully support email-based integrations, they lack the security and real-time acknowledgement available with our <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>. Most of our customers do not consider email-based integrations to be “real” integrations and will ask for something better.
+  </li>
+</ul>
+<p>
+  <strong>If you are integrating a proprietary, in-house monitoring tool with PagerDuty</strong>, we recommending using the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>. You can also use the <a href="https://www.pagerduty.com/docs/guides/agent-install-guide/">PD Agent</a>.
+</p>
+<p>
+  <strong>If your monitoring tool will be used by other companies</strong>, we recommend implementing <a href="https://www.pagerduty.com/docs/guides/pagerduty-connect/">PD Connect</a> and the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a> to provide a one-click integration for your customers. We also strongly recommend that you write an integration guide (with screenshots) that walks your customers through the process on both your application and PagerDuty. If you do so, we will host your integration guide on our site, add your company to our Partners page, and provide a complementary single-user PagerDuty account for your ongoing integration testing needs.
+</p>
+<p>
+  <strong>If it’s relevant to your application, we strongly recommend creating a bi-directional integration.</strong> We’ve found our customers have come to expect their monitoring and incident management tools to remain in sync. PagerDuty can send incident updates (e.g., acknowledge/resolve) to your application in two different ways:
+</p>
+<ul>
+  <li>
+    <strong>Best:</strong> <a href="https://developer.pagerduty.com/documentation/rest/webhooks">Webhooks</a>. PagerDuty can automatically send HTTP callbacks whenever an incident is triggered, acknowledged, unacknowledged (due to timeout), resolved, reassigned, escalated, or delegated. Webhooks are specific to a Service. This is the preferred method for SaaS-based monitoring tools.
+  </li>
+  <li>
+    <strong>Okay:</strong> Regularly poll the <a href="https://developer.pagerduty.com/documentation/rest/incidents">Incidents API</a> for <a href="https://developer.pagerduty.com/documentation/rest/incidents/show">details about incidents</a> you’ve sent over. Webhooks are preferable because the <a href="https://developer.pagerduty.com/documentation/rest/incidents">Incidents API</a> requires an additional, distinct <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> and polling isn’t fun for anyone. This is only option for those running software behind an impenetrable firewall.
+  </li>
+</ul>
+<p>
+  <strong>If your monitoring tool has the notion of maintenance windows</strong>, you may want to develop an integration with our <a href="https://developer.pagerduty.com/documentation/rest/maintenance_windows">Maintenance Windows API</a> to keep the maintenance windows between your application and PagerDuty in sync. A bi-directional integration will require polling, but a longer interval should work relatively well. Note: this API requires the use of a <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> (distinct from the "Service Key" used by the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>).
+</p>
+<p>
+  <strong>If your monitoring tool has the notion of notes</strong>, you can also <a href="https://developer.pagerduty.com/documentation/rest/incidents/notes/list">read</a> and <a href="https://developer.pagerduty.com/documentation/rest/incidents/notes/create">add</a> notes to incidents. A bi-directional integration will require polling. Note: this API requires the use of a <a href="https://support.pagerduty.com/hc/en-us/articles/202829310-Generating-an-API-Key">API Access Key</a> (distinct from the “Service Key” used by the <a href="https://developer.pagerduty.com/documentation/integration/events">Integration API</a>).
+</p>

--- a/source/documentation/integration/events/acknowledge.html
+++ b/source/documentation/integration/events/acknowledge.html
@@ -2,63 +2,150 @@
 title: PagerDuty Developer
 layout: main
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/integration/events/">Integration</a></li>
-                    <span class="divider">/</span>
-                    <li><a href="/documentation/integration/events/">Events</a></li>
-                    <span class="divider">/</span>
-                    <li>Acknowledge</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">Acknowledge Events</h1>
-                    <p>Acknowledge events cause the referenced incident to enter the acknowledged state. While an incident is acknowledged, it won't generate any additional notifications, even if it receives new trigger events. Your monitoring tools should send PagerDuty an acknowledge event when they know someone is presently working on the problem.</p>
-                    <h3>Parameters</h3>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Name</th>
-                          <th>Type</th>
-                          <th>Required</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>service_key</td>
-                            <td><a href="/documentation/rest/types#string">String</a></td>
-                            <td>Yes</td>
-                            <td>The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.</td>
-                          </tr>
-                          <tr>
-                            <td>event_type</td>
-                            <td><a href="/documentation/rest/types#string">String</a></td>
-                            <td>Yes</td>
-                            <td>Set this to "acknowledge".</td>
-                          </tr>
-                          <tr>
-                            <td>incident_key</td>
-                            <td><a href="/documentation/rest/types#string">String</a></td>
-                            <td>Yes</td>
-                            <td>Identifies the incident to acknowledge. This should be the <code>incident_key</code> you received back when the incident was first opened by a trigger event. Acknowledge events referencing resolved or nonexistent incidents will be discarded.</td>
-                          </tr>
-                          <tr>
-                            <td>description</td>
-                            <td><a href="/documentation/rest/types#string">String</a></td>
-                            <td>No</td>
-                            <td>Text that will appear in the incident's log associated with this event.</td>
-                          </tr>
-                          <tr>
-                            <td>details</td>
-                            <td><a href="/documentation/rest/types#object">Object</a></td>
-                            <td>No</td>
-                            <td>An arbitrary JSON object containing any data you'd like included in the incident log.</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>Example</h3>
-                    <pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \&#x000A;    -d '{    &#x000A;      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",&#x000A;      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",&#x000A;      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>acknowledge</span>",&#x000A;      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Andrew now working on the problem.</span>",&#x000A;      "details": {&#x000A;        "work started": "<span class='curl_params-work started contenteditable' contenteditable='true'>2010-06-10 05:43</span>"&#x000A;      }&#x000A;    }' \&#x000A;    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code></pre>
-                    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-                    <div class="response">
-                      <pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;status&quot;: &quot;success&quot;,&#x000A;  &quot;message&quot;: &quot;Event processed&quot;,&#x000A;  &quot;incident_key&quot;: &quot;srv01/HTTP&quot;&#x000A;}</code></pre>
-                    </div>
-                  </div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/integration/events/">Integration</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/integration/events/">Events</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Acknowledge
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    Acknowledge Events
+  </h1>
+  <p>
+    Acknowledge events cause the referenced incident to enter the acknowledged state. While an incident is acknowledged, it won't generate any additional notifications, even if it receives new trigger events. Your monitoring tools should send PagerDuty an acknowledge event when they know someone is presently working on the problem.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            event_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Set this to "acknowledge".
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Identifies the incident to acknowledge. This should be the <code>incident_key</code> you received back when the incident was first opened by a trigger event. Acknowledge events referencing resolved or nonexistent incidents will be discarded.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Text that will appear in the incident's log associated with this event.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            details
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            An arbitrary JSON object containing any data you'd like included in the incident log.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \
+    -d '{    
+      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",
+      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",
+      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>acknowledge</span>",
+      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Andrew now working on the problem.</span>",
+      "details": {
+        "work started": "<span class='curl_params-work started contenteditable' contenteditable='true'>2010-06-10 05:43</span>"
+      }
+    }' \
+    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "status": "success",
+  "message": "Event processed",
+  "incident_key": "srv01/HTTP"
+}</code>
+</pre>
+  </div>
+</div>

--- a/source/documentation/integration/events/index.html
+++ b/source/documentation/integration/events/index.html
@@ -6,158 +6,329 @@ redirect_from:
   - /documentation/integration/events.html
   - /documentation/integration/
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/integration/events/">Integration</a></li>
-                    <span class="divider">/</span>
-                    <li>Events</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">Integration API</h1>
-                    <p>The PagerDuty event integration API is how you would add PagerDuty's advanced alerting functionality to any system that can make an HTTP API call. You can now add phone, SMS and email alerting to your monitoring tools, ticketing systems and custom software.</p>
-                    <h3>Description</h3>
-                    <p>The API was designed to allow you to easily integrate a monitoring system with a Service in PagerDuty. Monitoring systems generally send out events when problems are detected and when these problems have been resolved (fixed). Some more advanced systems also understand the concept of acknowledgements: problems can be acknowledged by an engineer to signal he or she is working on fixing the issue.</p>
-                    <p>Since monitoring systems emit events, the API is based around accepting events. Incoming events (sent via the API) are routed to a PagerDuty service and processed. They may result in a new incident being created, or an existing incident being acknowledged or resolved.</p>
-                    <p>The same event-based API can also be used to integrate a PagerDuty service with ticketing systems and various other software tools.</p>
-                    <p><strong>Interested in becoming a PagerDuty partner? Fill out <a href='http://www.pagerduty.com/partner-integrations/#section4' target='_blank' title='this form'>this form</a> for more information.</strong></p>
-                    <h2>Getting Started</h2>
-                    <p>The event integration API can be used with any "Generic API" service in PagerDuty. If you don't already have a "Generic API" service, you should create one:</p>
-                    <ol>
-                      <li>In your account, under the Services tab, click "Add New Service".</li>
-                      <li>Enter a name for the service and select an escalation policy. Then, select "Generic API" for the Service Type.</li>
-                      <li>Click the "Add Service" button.</li>
-                      <li>Once the service is created, you'll be taken to the service page. On this page, you'll see the "Service key", which is needed to access the API</li>
-                    </ol>
-                    <h2>Making a Request</h2>
-                    <p>To make an API request, POST a JSON object of the desired event type to the following URL</p>
-                    <pre>https://events.pagerduty.com/generic/2010-04-15/create_event.json</pre>
-                    <h3>Event Types</h3>
-                    <table class='table'>
-                      <caption>Click on an event type below for full details.</caption>
-                      <thead>
-                        <tr>
-                          <th>Event Type</th>
-                          <th>Description</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td><a href="/documentation/integration/events/trigger">Trigger</a></td>
-                          <td>Your monitoring tools should send PagerDuty a trigger event to report a new or ongoing problem. When PagerDuty receives a trigger event, it will either open a new incident, or add a new trigger log entry to an existing incident, depending on the provided <code>incident_key</code>.</td>
-                        </tr>
-                        <tr>
-                          <td><a href="/documentation/integration/events/acknowledge">Acknowledge</a></td>
-                          <td>Acknowledge events cause the referenced incident to enter the acknowledged state. While an incident is acknowledged, it won't generate any additional notifications, even if it receives new trigger events. Your monitoring tools should send PagerDuty an acknowledge event when they know someone is presently working on the problem.</td>
-                        </tr>
-                        <tr>
-                          <td><a href="/documentation/integration/events/resolve">Resolve</a></td>
-                          <td>Resolve events cause the referenced incident to enter the resolved state. Once an incident is resolved, it won't generate any additional notifications. New trigger events with the same <code>incident_key</code> as a resolved incident won't re-open the incident. Instead, a new incident will be created. Your monitoring tools should send PagerDuty a resolve event when the problem that caused the initial trigger event has been fixed.</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <h2>API Response Codes &amp; Retry Logic</h2>
-                    <p>Ideally, the API request will succeed and the PagerDuty server will indicate that it successfully received that event. In practice, the request may fail due to various reasons.
-                    </p>
-                    <p>The following table shows the possible results of the API request and if you need to retry the API call for that result:</p>
-                    <table class='table'>
-                      <thead>
-                        <tr>
-                          <th>Result</th>
-                          <th>Description</th>
-                          <th>Retry?</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td><code>200</code></td>
-                          <td>OK - The event has been accepted by PagerDuty. See below for details.</td>
-                          <td>No</td>
-                        </tr>
-                        <tr>
-                          <td>
-                            <code>400</code>
-                          </td>
-                          <td>Bad Request - Check that the JSON is valid. See below for details.</td>
-                          <td>No</td>
-                        </tr>
-                        <tr>
-                          <td><code>403</code></td>
-                          <td>Forbidden - Too many API calls at a time.</td>
-                          <td><b>Yes - retry after some time.</b></td>
-                        </tr>
-                        <tr>
-                          <td><code>500</code>or other<b>5XX</b></td>
-                          <td>Internal Server Error - the PagerDuty server experienced an error while processing the event.</td>
-                          <td><b>Yes - retry after some time.</b></td>
-                        </tr>
-                        <tr>
-                          <td>Networking Error</td>
-                          <td>Error while trying to communicate with PagerDuty servers.</td>
-                          <td><b>Yes - retry after some time.</b></td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <h2>Success</h2>
-                    <p>If the request is well-formatted, PagerDuty will respond with HTTP code <code class='language-bash'>200</code> and a JSON object with the following fields:</p>
-                    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-                    <div class="response">
-                      <pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;status&quot;: &quot;success&quot;,&#x000A;  &quot;incident_key&quot;: &quot;My Incident Key&quot;,&#x000A;  &quot;message&quot;: &quot;Event processed&quot;&#x000A;}</code></pre>
-                    </div>
-                    <h3>Response Fields</h3>
-                      <div class="table-container">
-                        <table class="table table-striped">
-                          <thead>
-                            <th>Name</th>
-                            <th>Type</th>
-                            <th>Description</th>
-                          </thead>
-                          <tbody>
-                            <tr>
-                              <td>status</td>
-                              <td><a href="/documentation/rest/types#string">String</a></td>
-                              <td>success</td>
-                            </tr>
-                            <tr>
-                              <td>message</td>
-                              <td><a href="/documentation/rest/types#string">String</a></td>
-                              <td>Event processed</td>
-                            </tr>
-                            <tr>
-                              <td>incident_key</td>
-                              <td><a href="/documentation/rest/types#string">String</a></td>
-                              <td>The key of the incident that will be affected by the request.</td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
-                      <h2>Bad Request</h2>
-                      <p>If the request is invalid, PagerDuty will respond with HTTP code <code>400</code> and an object with the following fields:</p>
-                      <h3>Response Fields</h3>
-                      <div class="table-container">
-                        <table class="table table-striped">
-                          <thead>
-                            <th>Name</th>
-                            <th>Type</th>
-                            <th>Description</th>
-                          </thead>
-                          <tbody>
-                            <tr>
-                              <td>status</td>
-                              <td><a href="/documentation/rest/types#string">String</a></td>
-                              <td>invalid event</td>
-                            </tr>
-                            <tr>
-                              <td>message</td>
-                              <td><a href="/documentation/rest/types#string">String</a></td><td>A description of the problem</td>
-                            </tr>
-                            <tr>
-                              <td>errors</td>
-                              <td><a href="/documentation/rest/types#array">Array</a></td>
-                              <td>An array of specific error messages</td>
-                            </tr>
-                          </tbody>
-                        </table>
-                      </div>
-                      <h2>API Limits</h2>
-                      <p>There is a limit on the number of events that a service can accept at any given time. Depending on the behavior of the incoming traffic and how many incidents are being created at once, we reduce our throttle dynamically.</p>
-                      <p>If each of the events your monitoring system is sending is important, be sure to retry on a 403 response code, preferably with a back off.</p>
-                  </div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/integration/events/">Integration</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Events
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    Integration API
+  </h1>
+  <p>
+    The PagerDuty event integration API is how you would add PagerDuty's advanced alerting functionality to any system that can make an HTTP API call. You can now add phone, SMS and email alerting to your monitoring tools, ticketing systems and custom software.
+  </p>
+  <h3>
+    Description
+  </h3>
+  <p>
+    The API was designed to allow you to easily integrate a monitoring system with a Service in PagerDuty. Monitoring systems generally send out events when problems are detected and when these problems have been resolved (fixed). Some more advanced systems also understand the concept of acknowledgements: problems can be acknowledged by an engineer to signal he or she is working on fixing the issue.
+  </p>
+  <p>
+    Since monitoring systems emit events, the API is based around accepting events. Incoming events (sent via the API) are routed to a PagerDuty service and processed. They may result in a new incident being created, or an existing incident being acknowledged or resolved.
+  </p>
+  <p>
+    The same event-based API can also be used to integrate a PagerDuty service with ticketing systems and various other software tools.
+  </p>
+  <p>
+    <strong>Interested in becoming a PagerDuty partner? Fill out <a href='http://www.pagerduty.com/partner-integrations/#section4' target='_blank' title='this form'>this form</a> for more information.</strong>
+  </p>
+  <h2>
+    Getting Started
+  </h2>
+  <p>
+    The event integration API can be used with any "Generic API" service in PagerDuty. If you don't already have a "Generic API" service, you should create one:
+  </p>
+  <ol>
+    <li>In your account, under the Services tab, click "Add New Service".
+    </li>
+    <li>Enter a name for the service and select an escalation policy. Then, select "Generic API" for the Service Type.
+    </li>
+    <li>Click the "Add Service" button.
+    </li>
+    <li>Once the service is created, you'll be taken to the service page. On this page, you'll see the "Service key", which is needed to access the API
+    </li>
+  </ol>
+  <h2>
+    Making a Request
+  </h2>
+  <p>
+    To make an API request, POST a JSON object of the desired event type to the following URL
+  </p>
+  <pre>
+https://events.pagerduty.com/generic/2010-04-15/create_event.json
+</pre>
+  <h3>
+    Event Types
+  </h3>
+  <table class='table'>
+    <caption>
+      Click on an event type below for full details.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Event Type
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/integration/events/trigger">Trigger</a>
+        </td>
+        <td>
+          Your monitoring tools should send PagerDuty a trigger event to report a new or ongoing problem. When PagerDuty receives a trigger event, it will either open a new incident, or add a new trigger log entry to an existing incident, depending on the provided <code>incident_key</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/integration/events/acknowledge">Acknowledge</a>
+        </td>
+        <td>
+          Acknowledge events cause the referenced incident to enter the acknowledged state. While an incident is acknowledged, it won't generate any additional notifications, even if it receives new trigger events. Your monitoring tools should send PagerDuty an acknowledge event when they know someone is presently working on the problem.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/integration/events/resolve">Resolve</a>
+        </td>
+        <td>
+          Resolve events cause the referenced incident to enter the resolved state. Once an incident is resolved, it won't generate any additional notifications. New trigger events with the same <code>incident_key</code> as a resolved incident won't re-open the incident. Instead, a new incident will be created. Your monitoring tools should send PagerDuty a resolve event when the problem that caused the initial trigger event has been fixed.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>
+    API Response Codes &amp; Retry Logic
+  </h2>
+  <p>
+    Ideally, the API request will succeed and the PagerDuty server will indicate that it successfully received that event. In practice, the request may fail due to various reasons.
+  </p>
+  <p>
+    The following table shows the possible results of the API request and if you need to retry the API call for that result:
+  </p>
+  <table class='table'>
+    <thead>
+      <tr>
+        <th>
+          Result
+        </th>
+        <th>
+          Description
+        </th>
+        <th>
+          Retry?
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>200</code>
+        </td>
+        <td>
+          OK - The event has been accepted by PagerDuty. See below for details.
+        </td>
+        <td>
+          No
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>400</code>
+        </td>
+        <td>
+          Bad Request - Check that the JSON is valid. See below for details.
+        </td>
+        <td>
+          No
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>403</code>
+        </td>
+        <td>
+          Forbidden - Too many API calls at a time.
+        </td>
+        <td>
+          <b>Yes - retry after some time.</b>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>500</code>or other<b>5XX</b>
+        </td>
+        <td>
+          Internal Server Error - the PagerDuty server experienced an error while processing the event.
+        </td>
+        <td>
+          <b>Yes - retry after some time.</b>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Networking Error
+        </td>
+        <td>
+          Error while trying to communicate with PagerDuty servers.
+        </td>
+        <td>
+          <b>Yes - retry after some time.</b>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>
+    Success
+  </h2>
+  <p>
+    If the request is well-formatted, PagerDuty will respond with HTTP code <code class='language-bash'>200</code> and a JSON object with the following fields:
+  </p>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "status": "success",
+  "incident_key": "My Incident Key",
+  "message": "Event processed"
+}</code>
+</pre>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            success
+          </td>
+        </tr>
+        <tr>
+          <td>
+            message
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Event processed
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The key of the incident that will be affected by the request.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Bad Request
+  </h2>
+  <p>
+    If the request is invalid, PagerDuty will respond with HTTP code <code>400</code> and an object with the following fields:
+  </p>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            invalid event
+          </td>
+        </tr>
+        <tr>
+          <td>
+            message
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A description of the problem
+          </td>
+        </tr>
+        <tr>
+          <td>
+            errors
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of specific error messages
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    API Limits
+  </h2>
+  <p>
+    There is a limit on the number of events that a service can accept at any given time. Depending on the behavior of the incoming traffic and how many incidents are being created at once, we reduce our throttle dynamically.
+  </p>
+  <p>
+    If each of the events your monitoring system is sending is important, be sure to retry on a 403 response code, preferably with a back off.
+  </p>
+</div>

--- a/source/documentation/integration/events/resolve.html
+++ b/source/documentation/integration/events/resolve.html
@@ -2,19 +2,150 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/integration/events/">Integration</a></li><span class="divider">/</span><li><a href="/documentation/integration/events">Events</a></li><span class="divider">/</span><li>Resolve</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/integration/events/">Integration</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/integration/events">Events</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Resolve
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Resolve Events</h1>
-<p>Resolve events cause the referenced incident to enter the resolved state. Once an incident is resolved, it won't generate any additional notifications. New trigger events with the same <code>incident_key</code> as a resolved incident won't re-open the incident. Instead, a new incident will be created. Your monitoring tools should send PagerDuty a resolve event when the problem that caused the initial trigger event has been fixed.</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The GUID of one of your "Events API" services. This is the "service key" listed on a Generic API's service detail page.
-</td></tr><tr><td>event_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>Set this to "resolve".
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>Identifies the incident to resolve. This should be the <code>incident_key</code> you received back when
-the incident was first opened by a trigger event. Resolve events referencing resolved
-or nonexistent incidents will be discarded.
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Text that will appear in the incident's log associated with this event.
-</td></tr><tr><td>details</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>An arbitrary JSON object containing any data you'd like included in the incident log.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \&#x000A;    -d '{    &#x000A;      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",&#x000A;      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",&#x000A;      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>resolve</span>",&#x000A;      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Andrew fixed the problem.</span>",&#x000A;      "details": {&#x000A;        "fixed at": "<span class='curl_params-fixed at contenteditable' contenteditable='true'>2010-06-10 06:00</span>"&#x000A;      }&#x000A;    }' \&#x000A;    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;status&quot;: &quot;success&quot;,&#x000A;  &quot;message&quot;: &quot;Event processed&quot;,&#x000A;  &quot;incident_key&quot;: &quot;srv01/HTTP&quot;&#x000A;}</code></pre></div>
+  <h1 class="title">
+    Resolve Events
+  </h1>
+  <p>
+    Resolve events cause the referenced incident to enter the resolved state. Once an incident is resolved, it won't generate any additional notifications. New trigger events with the same <code>incident_key</code> as a resolved incident won't re-open the incident. Instead, a new incident will be created. Your monitoring tools should send PagerDuty a resolve event when the problem that caused the initial trigger event has been fixed.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The GUID of one of your "Events API" services. This is the "service key" listed on a Generic API's service detail page.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            event_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Set this to "resolve".
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Identifies the incident to resolve. This should be the <code>incident_key</code> you received back when the incident was first opened by a trigger event. Resolve events referencing resolved or nonexistent incidents will be discarded.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Text that will appear in the incident's log associated with this event.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            details
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            An arbitrary JSON object containing any data you'd like included in the incident log.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \
+    -d '{    
+      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",
+      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",
+      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>resolve</span>",
+      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Andrew fixed the problem.</span>",
+      "details": {
+        "fixed at": "<span class='curl_params-fixed at contenteditable' contenteditable='true'>2010-06-10 06:00</span>"
+      }
+    }' \
+    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "status": "success",
+  "message": "Event processed",
+  "incident_key": "srv01/HTTP"
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/integration/events/trigger.html
+++ b/source/documentation/integration/events/trigger.html
@@ -2,38 +2,217 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/integration/events/">Integration</a></li><span class="divider">/</span><li><a href="/documentation/integration/events/">Events</a></li><span class="divider">/</span><li>Trigger</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/integration/events/">Integration</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/integration/events/">Events</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Trigger
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Trigger Events</h1>
-<p>Your monitoring tools should send PagerDuty a trigger event to report a new or ongoing problem. When PagerDuty receives a trigger event, it will either open a new incident, or add a new trigger log entry to an existing incident, depending on the provided <code>incident_key</code>.</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.
-</td></tr><tr><td>event_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>Set this to "trigger".
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>A short description of the problem that led to this trigger. This field (or a truncated version)
-will be used when generating phone calls, SMS messages and alert emails. It will also appear
-on the incidents tables in the PagerDuty UI. The maximum length is 1024 characters.
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>Identifies the incident to which this trigger event should be applied. If there's no open (i.e. unresolved) incident
-with this key, a new one will be created. If there's already an open incident with a matching key,
-this event will be appended to that incident's log. The event key provides an easy way to "de-dup"
-problem reports.
-</td></tr><tr><td>client</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the monitoring client that is triggering this event.
-</td></tr><tr><td>client_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The URL of the monitoring client that is triggering this event.
-</td></tr><tr><td>details</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>An arbitrary JSON object containing any data you'd like included in the incident log.
-</td></tr></tbody></table></div><h3>Example 1</h3>
-<p>
-This example shows how to make a request with a specific <code>incident_key</code>.
-Note that if an incident with this key already exists, this trigger message will simply be appended to it.
-If no incident with this key exists, a new one will be automatically created. When the <code>incident_key</code>
-is provided in the request, the same value will always be returned in the response.
-</p>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \&#x000A;    -d '{    &#x000A;      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",&#x000A;      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",&#x000A;      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>trigger</span>",&#x000A;      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>FAILURE for production/HTTP on machine srv01.acme.com</span>",&#x000A;      "client": "<span class='curl_params-client contenteditable' contenteditable='true'>Sample Monitoring Service</span>",&#x000A;      "client_url": "<span class='curl_params-client_url contenteditable' contenteditable='true'>https://monitoring.service.com</span>",&#x000A;      "details": {&#x000A;        "ping time": "<span class='curl_params-ping time contenteditable' contenteditable='true'>1500ms</span>",&#x000A;        "load avg": 0.75&#x000A;      }&#x000A;    }' \&#x000A;    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;status&quot;: &quot;success&quot;,&#x000A;  &quot;message&quot;: &quot;Event processed&quot;,&#x000A;  &quot;incident_key&quot;: &quot;srv01/HTTP&quot;&#x000A;}</code></pre></div>
-<h3>Example 2</h3>
-<p>
-This example shows how to make a request without an <code>incident_key</code>. In this case, PagerDuty will
-automatically assign a random and unique key and return it in the response object. You should store this
-key in case you want to send an acknowledge or resolve event to this incident in the future.
-</p>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \&#x000A;    -d '{    &#x000A;      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",&#x000A;      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>trigger</span>",&#x000A;      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>FAILURE for production/HTTP on machine srv01.acme.com</span>",&#x000A;      "client": "<span class='curl_params-client contenteditable' contenteditable='true'>Sample Monitoring Service</span>",&#x000A;      "client_url": "<span class='curl_params-client_url contenteditable' contenteditable='true'>https://monitoring.service.com</span>",&#x000A;      "details": {&#x000A;        "ping time": "<span class='curl_params-ping time contenteditable' contenteditable='true'>1500ms</span>",&#x000A;        "load avg": 0.75&#x000A;      }&#x000A;    }' \&#x000A;    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;status&quot;: &quot;success&quot;,&#x000A;  &quot;message&quot;: &quot;Event processed&quot;,&#x000A;  &quot;incident_key&quot;: &quot;73af7a305bd7012d7c06002500d5d1a6&quot;&#x000A;}</code></pre></div>
+  <h1 class="title">
+    Trigger Events
+  </h1>
+  <p>
+    Your monitoring tools should send PagerDuty a trigger event to report a new or ongoing problem. When PagerDuty receives a trigger event, it will either open a new incident, or add a new trigger log entry to an existing incident, depending on the provided <code>incident_key</code>.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            event_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Set this to "trigger".
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A short description of the problem that led to this trigger. This field (or a truncated version) will be used when generating phone calls, SMS messages and alert emails. It will also appear on the incidents tables in the PagerDuty UI. The maximum length is 1024 characters.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Identifies the incident to which this trigger event should be applied. If there's no open (i.e. unresolved) incident with this key, a new one will be created. If there's already an open incident with a matching key, this event will be appended to that incident's log. The event key provides an easy way to "de-dup" problem reports.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            client
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the monitoring client that is triggering this event.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            client_url
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The URL of the monitoring client that is triggering this event.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            details
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            An arbitrary JSON object containing any data you'd like included in the incident log.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example 1
+  </h3>
+  <p>
+    This example shows how to make a request with a specific <code>incident_key</code>. Note that if an incident with this key already exists, this trigger message will simply be appended to it. If no incident with this key exists, a new one will be automatically created. When the <code>incident_key</code> is provided in the request, the same value will always be returned in the response.
+  </p>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \
+    -d '{    
+      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",
+      "incident_key": "<span class='curl_params-incident_key contenteditable' contenteditable='true'>srv01/HTTP</span>",
+      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>trigger</span>",
+      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>FAILURE for production/HTTP on machine srv01.acme.com</span>",
+      "client": "<span class='curl_params-client contenteditable' contenteditable='true'>Sample Monitoring Service</span>",
+      "client_url": "<span class='curl_params-client_url contenteditable' contenteditable='true'>https://monitoring.service.com</span>",
+      "details": {
+        "ping time": "<span class='curl_params-ping time contenteditable' contenteditable='true'>1500ms</span>",
+        "load avg": 0.75
+      }
+    }' \
+    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "status": "success",
+  "message": "Event processed",
+  "incident_key": "srv01/HTTP"
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example 2
+  </h3>
+  <p>
+    This example shows how to make a request without an <code>incident_key</code>. In this case, PagerDuty will automatically assign a random and unique key and return it in the response object. You should store this key in case you want to send an acknowledge or resolve event to this incident in the future.
+  </p>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -X POST \
+    -d '{    
+      "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>e93facc04764012d7bfb002500d5d1a6</span>",
+      "event_type": "<span class='curl_params-event_type contenteditable' contenteditable='true'>trigger</span>",
+      "description": "<span class='curl_params-description contenteditable' contenteditable='true'>FAILURE for production/HTTP on machine srv01.acme.com</span>",
+      "client": "<span class='curl_params-client contenteditable' contenteditable='true'>Sample Monitoring Service</span>",
+      "client_url": "<span class='curl_params-client_url contenteditable' contenteditable='true'>https://monitoring.service.com</span>",
+      "details": {
+        "ping time": "<span class='curl_params-ping time contenteditable' contenteditable='true'>1500ms</span>",
+        "load avg": 0.75
+      }
+    }' \
+    "https://events.pagerduty.com/generic/2010-04-15/create_event.json"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "status": "success",
+  "message": "Event processed",
+  "incident_key": "73af7a305bd7012d7c06002500d5d1a6"
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/alerts/index.html
+++ b/source/documentation/rest/alerts/index.html
@@ -5,14 +5,46 @@ permalink: /documentation/rest/alerts/
 redirect_from:
   - /documentation/rest/alerts.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Alerts</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Alerts
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Alerts API</h1>
-<p>
-When an <a href="/documentation/rest/incidents">incident</a> is triggered or when it is escalated it creates an alert
-(also known as a <i>notification</i>). Alerts are messages containing the details of the incident,
-and can be sent through SMS, email, phone calls, and push notifications.
-</p>
-<table class="table action_index"><caption>This API allows you to access read-only data regarding what alerts have been sent to your users.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/alerts/list">GET alerts</a></td><td>List existing alerts for a given time range, optionally filtered by type (SMS, Email, Phone, or Push).</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Alerts API
+  </h1>
+  <p>
+    When an <a href="/documentation/rest/incidents">incident</a> is triggered or when it is escalated it creates an alert (also known as a <i>notification</i>). Alerts are messages containing the details of the incident, and can be sent through SMS, email, phone calls, and push notifications.
+  </p>
+  <table class="table action_index">
+    <caption>
+      This API allows you to access read-only data regarding what alerts have been sent to your users.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/alerts/list">GET alerts</a>
+        </td>
+        <td>
+          List existing alerts for a given time range, optionally filtered by type (SMS, Email, Phone, or Push).
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/alerts/list.html
+++ b/source/documentation/rest/alerts/list.html
@@ -5,12 +5,227 @@ permalink: /documentation/rest/alerts/list/
 redirect_from:
   - /documentation/rest/alerts/list.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest/">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/alerts/">Alerts</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest/">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/alerts/">Alerts</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET alerts</h1><p>List existing alerts for a given time range, optionally filtered by type (SMS, Email, Phone, or Push).</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/alerts</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination/">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start of the date range over which you want to search. The time element is optional.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end of the date range over which you want to search. This should be in the same format as <code>since</code>. The size of the date range must be less than 3 months.
-</td></tr><tr><td>filter[type]</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Returns only the alerts of the said types. Can be one of <code>SMS</code>, <code>Email</code>, <code>Phone</code>, or <code>Push</code>.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to account time zone.
-</td></tr></tbody></table></div><h3>Examples</h3>
-<h3>Alerts with Date Range</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2013-03-06T15:28-05</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2013-03-06T15:30-05</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/alerts"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;alerts&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PWL7QXS&quot;,&#x000A;      &quot;type&quot;: &quot;Phone&quot;,&#x000A;      &quot;started_at&quot;: &quot;2013-03-06T15:28:50-05:00&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;address&quot;: &quot;+15555551234&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKN7NBH&quot;,&#x000A;      &quot;type&quot;: &quot;Email&quot;,&#x000A;      &quot;started_at&quot;: &quot;2013-03-06T15:28:51-05:00&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;address&quot;: &quot;tim@pagerduty.com&quot;&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 2&#x000A;}</code></pre></div><h3>Alerts Filtered by Phone</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2013-03-06T15:28-05</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2013-03-06T15:30-05</span>" \&#x000A;    --data-urlencode "filter[type]=<span class='curl_params-filter[type] contenteditable' contenteditable='true'>phone</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/alerts"</code></pre><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;alerts&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PWL7QXS&quot;,&#x000A;      &quot;type&quot;: &quot;Phone&quot;,&#x000A;      &quot;started_at&quot;: &quot;2013-03-06T15:28:50-05:00&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;address&quot;: &quot;+15555551234&quot;&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET alerts
+  </h1>
+  <p>
+    List existing alerts for a given time range, optionally filtered by type (SMS, Email, Phone, or Push).
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/alerts
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination/">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start of the date range over which you want to search. The time element is optional.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The end of the date range over which you want to search. This should be in the same format as <code>since</code>. The size of the date range must be less than 3 months.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            filter[type]
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Returns only the alerts of the said types. Can be one of <code>SMS</code>, <code>Email</code>, <code>Phone</code>, or <code>Push</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to account time zone.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Examples
+  </h3>
+  <h3>
+    Alerts with Date Range
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2013-03-06T15:28-05</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2013-03-06T15:30-05</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/alerts"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "alerts": [
+    {
+      "id": "PWL7QXS",
+      "type": "Phone",
+      "started_at": "2013-03-06T15:28:50-05:00",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "address": "+15555551234"
+    },
+    {
+      "id": "PKN7NBH",
+      "type": "Email",
+      "started_at": "2013-03-06T15:28:51-05:00",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "address": "tim@pagerduty.com"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 2
+}</code>
+</pre>
+  </div>
+  <h3>
+    Alerts Filtered by Phone
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2013-03-06T15:28-05</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2013-03-06T15:30-05</span>" \
+    --data-urlencode "filter[type]=<span class='curl_params-filter[type] contenteditable' contenteditable='true'>phone</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/alerts"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "alerts": [
+    {
+      "id": "PWL7QXS",
+      "type": "Phone",
+      "started_at": "2013-03-06T15:28:50-05:00",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "address": "+15555551234"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 1
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/authentication.html
+++ b/source/documentation/rest/authentication.html
@@ -9,12 +9,26 @@ nav:
   - title: REST API
     url: /documentation/rest/
 ---
-                    <h1 class="title">API Authentication</h1>
-                    <h2>API Token Authentication</h2>
-                    <p>Our REST APIs support token authentication. Only an account administrator can access or <a href="http://support.pagerduty.com/entries/23761081-Generating-an-API-Key">generate API key tokens</a>.</p>
-                    <p>Here's a sample curl request that is authenticated using the API key token.</p>
-                    <pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-06-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-06-20</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/P4MHU96/entries"</code></pre>
-                    <div class='alert alert-block alert-info'>
-                      <h4>Important!</h4>
-                      All API requests must be made over <strong>HTTPS</strong>.Calls made over plain HTTP will be redirected to HTTPS.
-                    </div>
+<h1 class="title">
+  API Authentication
+</h1>
+<h2>
+  API Token Authentication
+</h2>
+<p>
+  Our REST APIs support token authentication. Only an account administrator can access or <a href="http://support.pagerduty.com/entries/23761081-Generating-an-API-Key">generate API key tokens</a>.
+</p>
+<p>
+  Here's a sample curl request that is authenticated using the API key token.
+</p>
+<pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-06-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-06-20</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/P4MHU96/entries"</code>
+</pre>
+<div class='alert alert-block alert-info'>
+  <h4>
+    Important!
+  </h4>All API requests must be made over <strong>HTTPS</strong>.Calls made over plain HTTP will be redirected to HTTPS.
+</div>

--- a/source/documentation/rest/errors.html
+++ b/source/documentation/rest/errors.html
@@ -9,132 +9,280 @@ nav:
   - title: REST API
     url: /documentation/rest/
 ---
-                    <h1 class="title">Errors</h1>
-                    <p>If an API request is successful, PagerDuty will respond to it with HTTP status code 2XX and the resources that match the query.</p>
-                    <p>If the API request is unsuccessful, PagerDuty will respond with a corresponding HTTP error status code and the response body will contain PagerDuty error details.</p>
-                    <p>The response body (with error details) will have the following properties:</p>
-                    <pre><code class='language-javascript'><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;error&quot;: {&#x000A;    &quot;message&quot;: &quot;Error Message String&quot;,&#x000A;    &quot;code&quot;: 2001,&#x000A;    &quot;errors&quot;: [&#x000A;      &quot;human-readable error details&quot;,&#x000A;      &quot;more details&quot;&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></code></pre>
-                    <a href="#" name="http_codes"></a>
-                    <h3>HTTP Responses</h3>
-                    <p>The HTTP response can be used to determine if the request was successful, and if not, whether the request should be retried.</p>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Code</th>
-                          <th>HTTP Definition</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>200</td>
-                            <td>OK</td>
-                            <td>The request was successful.</td>
-                          </tr>
-                          <tr>
-                            <td>201</td>
-                            <td>Created</td>
-                            <td>The request was successful and a new resource was created.</td>
-                          </tr>
-                          <tr>
-                            <td>204</td>
-                            <td>No Content</td>
-                            <td>The request was successful. No content is returned.</td>
-                          </tr>
-                          <tr>
-                            <td>400</td>
-                            <td>Bad Request</td>
-                            <td>Caller provided invalid arguments. Please review the response for error details. Retrying with the same arguments will *not* work.</td>
-                          </tr>
-                          <tr>
-                            <td>401</td>
-                            <td>Unauthorized</td>
-                            <td>Caller did not supply credentials or did not provide the correct credentials.</td>
-                          </tr>
-                          <tr>
-                            <td>403</td>
-                            <td>Forbidden</td>
-                            <td>Caller is not authorized to view the requested resource.</td>
-                          </tr>
-                          <tr>
-                            <td>404</td>
-                            <td>Not Found</td>
-                            <td>The requested resource was not found.</td>
-                          </tr>
-                          <tr>
-                            <td>408</td>
-                            <td>Request Timeout</td>
-                            <td>The request took too long to process. Please try again.</td>
-                          </tr>
-                          <tr>
-                            <td>500</td>
-                            <td>Internal Server Error</td>
-                            <td>Internal error occurred while processing request. Please try again.</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>PagerDuty Error Codes</h3>
-                    <p>In the case of an error, the PagerDuty error code can give further details on the nature of the error.</p>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Code</th>
-                          <th>Message</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>2000</td>
-                            <td>Internal Error</td>
-                          </tr>
-                          <tr>
-                            <td>2001</td>
-                            <td>Invalid Input Provided</td>
-                          </tr>
-                          <tr>
-                            <td>2002</td>
-                            <td>Arguments Caused Error</td>
-                          </tr>
-                          <tr>
-                            <td>2003</td>
-                            <td>Missing Arguments</td>
-                          </tr>
-                          <tr>
-                            <td>2004</td>
-                            <td>Invalid 'since' or 'until' Parameter Values</td>
-                          </tr>
-                          <tr>
-                            <td>2005</td>
-                            <td>Invalid Query Date Range</td>
-                          </tr>
-                          <tr>
-                            <td>2006</td>
-                            <td>Authentication Failed</td>
-                          </tr>
-                          <tr>
-                            <td>2007</td>
-                            <td>Account Not Found</td>
-                          </tr>
-                          <tr>
-                            <td>2008</td>
-                            <td>Account Locked</td>
-                          </tr>
-                          <tr>
-                            <td>2009</td>
-                            <td>Only HTTPS Allowed For This Call</td>
-                          </tr>
-                          <tr>
-                            <td>2010</td>
-                            <td>Access Denied</td>
-                          </tr>
-                          <tr>
-                            <td>2011</td>
-                            <td>The action requires a 'requester_id' to be specified</td>
-                          </tr>
-                          <tr>
-                            <td>2012</td>
-                            <td>Your account is expired and cannot use the API</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <p>In addition to a code and message, the return value will also include an array of human-readable reasons for the error in the <code>errors</code> field. These human-readable values, and even their format, are subject to change.</p>
+<h1 class="title">
+  Errors
+</h1>
+<p>
+  If an API request is successful, PagerDuty will respond to it with HTTP status code 2XX and the resources that match the query.
+</p>
+<p>
+  If the API request is unsuccessful, PagerDuty will respond with a corresponding HTTP error status code and the response body will contain PagerDuty error details.
+</p>
+<p>
+  The response body (with error details) will have the following properties:
+</p>
+<pre>
+<code class='language-javascript'><code class="language-javascript prettyprint linenums">{
+  "error": {
+    "message": "Error Message String",
+    "code": 2001,
+    "errors": [
+      "human-readable error details",
+      "more details"
+    ]
+  }
+}</code></code>
+</pre><a href="#" name="http_codes" id="http_codes"></a>
+<h3>
+  HTTP Responses
+</h3>
+<p>
+  The HTTP response can be used to determine if the request was successful, and if not, whether the request should be retried.
+</p>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Code
+        </th>
+        <th>
+          HTTP Definition
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          200
+        </td>
+        <td>
+          OK
+        </td>
+        <td>
+          The request was successful.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          201
+        </td>
+        <td>
+          Created
+        </td>
+        <td>
+          The request was successful and a new resource was created.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          204
+        </td>
+        <td>
+          No Content
+        </td>
+        <td>
+          The request was successful. No content is returned.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          400
+        </td>
+        <td>
+          Bad Request
+        </td>
+        <td>
+          Caller provided invalid arguments. Please review the response for error details. Retrying with the same arguments will *not* work.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          401
+        </td>
+        <td>
+          Unauthorized
+        </td>
+        <td>
+          Caller did not supply credentials or did not provide the correct credentials.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          403
+        </td>
+        <td>
+          Forbidden
+        </td>
+        <td>
+          Caller is not authorized to view the requested resource.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          404
+        </td>
+        <td>
+          Not Found
+        </td>
+        <td>
+          The requested resource was not found.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          408
+        </td>
+        <td>
+          Request Timeout
+        </td>
+        <td>
+          The request took too long to process. Please try again.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          500
+        </td>
+        <td>
+          Internal Server Error
+        </td>
+        <td>
+          Internal error occurred while processing request. Please try again.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<h3>
+  PagerDuty Error Codes
+</h3>
+<p>
+  In the case of an error, the PagerDuty error code can give further details on the nature of the error.
+</p>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Code
+        </th>
+        <th>
+          Message
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          2000
+        </td>
+        <td>
+          Internal Error
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2001
+        </td>
+        <td>
+          Invalid Input Provided
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2002
+        </td>
+        <td>
+          Arguments Caused Error
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2003
+        </td>
+        <td>
+          Missing Arguments
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2004
+        </td>
+        <td>
+          Invalid 'since' or 'until' Parameter Values
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2005
+        </td>
+        <td>
+          Invalid Query Date Range
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2006
+        </td>
+        <td>
+          Authentication Failed
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2007
+        </td>
+        <td>
+          Account Not Found
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2008
+        </td>
+        <td>
+          Account Locked
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2009
+        </td>
+        <td>
+          Only HTTPS Allowed For This Call
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2010
+        </td>
+        <td>
+          Access Denied
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2011
+        </td>
+        <td>
+          The action requires a 'requester_id' to be specified
+        </td>
+      </tr>
+      <tr>
+        <td>
+          2012
+        </td>
+        <td>
+          Your account is expired and cannot use the API
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<p>
+  In addition to a code and message, the return value will also include an array of human-readable reasons for the error in the <code>errors</code> field. These human-readable values, and even their format, are subject to change.
+</p>

--- a/source/documentation/rest/escalation_policies/create.html
+++ b/source/documentation/rest/escalation_policies/create.html
@@ -5,13 +5,187 @@ permalink: /documentation/rest/escalation_policies/create/
 redirect_from:
   - /documentation/rest/escalation_policies/create.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST escalation_policies</h1><p>Creates a new escalation policy. There must be at least one existing escalation rule added to create a new escalation policy.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the escalation policy.
-</td></tr><tr><td>repeat_enabled</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>Whether or not to allow this policy to repeat its escalation rules after the last rule is finished. Defaults to <code>false</code>.
-</td></tr><tr><td>num_loops</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The number of times to loop over the set of rules in this escalation policy.
-</td></tr><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>The escalation rules for this policy. The ordering and available parameters are found under the <a href="/documentation/rest/escalation_policies/escalation_rules/">Escalation Rules API</a>. There must be at least one rule to create a new escalation policy.
-</td></tr></tbody></table></div><h3>Example</h3>
-<h3>Create an escalation policy</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Escalation Policy</span>",&#x000A;      "escalation_rules": [&#x000A;        {&#x000A;          "escalation_delay_in_minutes": 22,&#x000A;          "targets": [&#x000A;            {&#x000A;              "type": "<span class='curl_params-type contenteditable' contenteditable='true'>user</span>",&#x000A;              "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"&#x000A;            }&#x000A;          ]&#x000A;        }&#x000A;      ],&#x000A;      "num_loops": 2&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_policy&quot;: {&#x000A;    &quot;id&quot;: &quot;PBZ3BZV&quot;,&#x000A;    &quot;name&quot;: &quot;Escalation Policy&quot;,&#x000A;    &quot;escalation_rules&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PYO9B13&quot;,&#x000A;        &quot;escalation_delay_in_minutes&quot;: 22,&#x000A;        &quot;rule_object&quot;: {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        },&#x000A;        &quot;targets&quot;: [&#x000A;          {&#x000A;            &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;            &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;red&quot;&#x000A;          }&#x000A;        ]&#x000A;      }&#x000A;    ],&#x000A;    &quot;services&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;num_loops&quot;: 2,&#x000A;    &quot;description&quot;: null&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST escalation_policies
+  </h1>
+  <p>
+    Creates a new escalation policy. There must be at least one existing escalation rule added to create a new escalation policy.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            repeat_enabled
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Whether or not to allow this policy to repeat its escalation rules after the last rule is finished. Defaults to <code>false</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            num_loops
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The number of times to loop over the set of rules in this escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The escalation rules for this policy. The ordering and available parameters are found under the <a href="/documentation/rest/escalation_policies/escalation_rules/">Escalation Rules API</a>. There must be at least one rule to create a new escalation policy.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Create an escalation policy
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Escalation Policy</span>",
+      "escalation_rules": [
+        {
+          "escalation_delay_in_minutes": 22,
+          "targets": [
+            {
+              "type": "<span class='curl_params-type contenteditable' contenteditable='true'>user</span>",
+              "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"
+            }
+          ]
+        }
+      ],
+      "num_loops": 2
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_policy": {
+    "id": "PBZ3BZV",
+    "name": "Escalation Policy",
+    "escalation_rules": [
+      {
+        "id": "PYO9B13",
+        "escalation_delay_in_minutes": 22,
+        "rule_object": {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        },
+        "targets": [
+          {
+            "id": "PPSFHH7",
+            "name": "Bob Smith",
+            "type": "user",
+            "email": "bob@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "red"
+          }
+        ]
+      }
+    ],
+    "services": [
+
+    ],
+    "num_loops": 2,
+    "description": null
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/delete.html
+++ b/source/documentation/rest/escalation_policies/delete.html
@@ -5,9 +5,53 @@ permalink: /documentation/rest/escalation_policies/delete/
 redirect_from:
   - /documentation/rest/escalation_policies/delete.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/">Escalation Policies</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE escalation_policies/:id</h1><p>Deletes an existing escalation policy and rules. The escalation policy must not be in use by any services.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<h3>Delete an escalation policy</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PF106PL</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE escalation_policies/:id
+  </h1>
+  <p>
+    Deletes an existing escalation policy and rules. The escalation policy must not be in use by any services.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Delete an escalation policy
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PF106PL</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/create.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/create.html
@@ -2,20 +2,315 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST escalation_policies/:escalation_policy_id/escalation_rules</h1><p>Creates a new escalation rule for an escalation policy and appends it to the end of the existing escalation rules.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The escalation timeout in minutes. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Yes</td><td>An object containing the <code>schedule</code> or <code>user</code> id and type.
-</td></tr></tbody></table></div><h3>Rule Object Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>A string of either <code>schedule</code> or <code>user</code>,
-</td></tr><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
-</td></tr></tbody></table></div><h3>Escalation Rule Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The escalation timeout in minutes. Must be at least <code>5</code> if the rule has multiple targets, and at least <code>1</code> if not. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-A single target. Ignored if <code>targets</code> is provided.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>The array of the targets an incident should be assigned to upon reaching this rule. Parameters detailed below.
-</td></tr></tbody></table></div><h3>Target Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>A string of either <code>schedule</code> or <code>user</code>,
-</td></tr><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Create an escalation rule</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"escalation_rule":{"escalation_delay_in_minutes":10,"targets":[{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>user</span>","id":"<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"}]}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PNTPYK0&quot;,&#x000A;    &quot;escalation_delay_in_minutes&quot;: 10,&#x000A;    &quot;rule_object&quot;: {&#x000A;      &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;      &quot;type&quot;: &quot;user&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;red&quot;&#x000A;    },&#x000A;    &quot;targets&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST escalation_policies/:escalation_policy_id/escalation_rules
+  </h1>
+  <p>
+    Creates a new escalation rule for an escalation policy and appends it to the end of the existing escalation rules.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The escalation timeout in minutes. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            An object containing the <code>schedule</code> or <code>user</code> id and type.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Rule Object Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A string of either <code>schedule</code> or <code>user</code>,
+          </td>
+        </tr>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Rule Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The escalation timeout in minutes. Must be at least <code>5</code> if the rule has multiple targets, and at least <code>1</code> if not. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>A single target. Ignored if <code>targets</code> is provided.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The array of the targets an incident should be assigned to upon reaching this rule. Parameters detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A string of either <code>schedule</code> or <code>user</code>,
+          </td>
+        </tr>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Create an escalation rule
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"escalation_rule":{"escalation_delay_in_minutes":10,"targets":[{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>user</span>","id":"<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"}]}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_rule": {
+    "id": "PNTPYK0",
+    "escalation_delay_in_minutes": 10,
+    "rule_object": {
+      "id": "PPSFHH7",
+      "name": "Bob Smith",
+      "type": "user",
+      "email": "bob@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "red"
+    },
+    "targets": [
+      {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/delete.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/delete.html
@@ -2,9 +2,59 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE escalation_policies/:escalation_policy_id/escalation_rules/:id</h1><p>Deletes an existing escalation rule that belongs to an escalation policy. There must be a matching rule.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<h3>Delete an escalation policy</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PF106PL</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PN0ZD20</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE escalation_policies/:escalation_policy_id/escalation_rules/:id
+  </h1>
+  <p>
+    Deletes an existing escalation rule that belongs to an escalation policy. There must be a matching rule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Delete an escalation policy
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PF106PL</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PN0ZD20</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/index.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/index.html
@@ -2,11 +2,89 @@
 title: Escalation Rules API
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li>Escalation Rules</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Escalation Rules
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Escalation Rules API</h1>
-<table class="table action_index"><caption>This API lets you access and manipulate escalation rules of an existing escalation policy.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/list">GET escalation_policies/:escalation_policy_id/escalation_rules</a></td><td>List escalation rules for an escalation policy.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/create">POST escalation_policies/:escalation_policy_id/escalation_rules</a></td><td>Append a new escalation rule to the existing escalation rules.</td></tr>
-<tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/multi_update">PUT escalation_policies/:escalation_policy_id/escalation_rules</a></td><td>Updates the entire collection of escalation rules.</td></tr>
-<tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/show">GET escalation_policies/:escalation_policy_id/escalation_rules/:id</a></td><td>Get details about an escalation rule.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/update">PUT escalation_policies/:escalation_policy_id/escalation_rules/:id</a></td><td>Update an escalation rule.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/escalation_rules/delete">DELETE escalation_policies/:escalation_policy_id/escalation_rules/:id</a></td><td>Delete an escalation rule.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Escalation Rules API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      This API lets you access and manipulate escalation rules of an existing escalation policy.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/list">GET escalation_policies/:escalation_policy_id/escalation_rules</a>
+        </td>
+        <td>
+          List escalation rules for an escalation policy.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/create">POST escalation_policies/:escalation_policy_id/escalation_rules</a>
+        </td>
+        <td>
+          Append a new escalation rule to the existing escalation rules.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/multi_update">PUT escalation_policies/:escalation_policy_id/escalation_rules</a>
+        </td>
+        <td>
+          Updates the entire collection of escalation rules.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/show">GET escalation_policies/:escalation_policy_id/escalation_rules/:id</a>
+        </td>
+        <td>
+          Get details about an escalation rule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/update">PUT escalation_policies/:escalation_policy_id/escalation_rules/:id</a>
+        </td>
+        <td>
+          Update an escalation rule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/escalation_rules/delete">DELETE escalation_policies/:escalation_policy_id/escalation_rules/:id</a>
+        </td>
+        <td>
+          Delete an escalation rule.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/list.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/list.html
@@ -2,23 +2,305 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET escalation_policies/:escalation_policy_id/escalation_rules</h1><p>List all the escalation rules for an existing escalation policy.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules</pre></div><h3>Parameters</h3><p>None</p>
-<h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>The collection of escalation rules for this escalation policy. Fields detailed below.
-</td></tr></tbody></table></div><h3>Escalation Rule Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation rule.
-</td></tr><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The amount of time before an incident escalates away from this rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-An object representing the first target.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
-</td></tr></tbody></table></div><h3>Target Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The id of the target.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the target.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's email address.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's personal time zone.
-</td></tr><tr><td>color</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The color used to represent the user in schedules.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Get all escalation rules</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_rules&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PYO9B13&quot;,&#x000A;      &quot;escalation_delay_in_minutes&quot;: 22,&#x000A;      &quot;rule_object&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      },&#x000A;      &quot;targets&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        }&#x000A;      ]&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PNTPYK0&quot;,&#x000A;      &quot;escalation_delay_in_minutes&quot;: 10,&#x000A;      &quot;rule_object&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      },&#x000A;      &quot;targets&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        }&#x000A;      ]&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET escalation_policies/:escalation_policy_id/escalation_rules
+  </h1>
+  <p>
+    List all the escalation rules for an existing escalation policy.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <p>
+    None
+  </p>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            The collection of escalation rules for this escalation policy. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Rule Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The amount of time before an incident escalates away from this rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>An object representing the first target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The id of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's personal time zone.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            color
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The color used to represent the user in schedules.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get all escalation rules
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_rules": [
+    {
+      "id": "PYO9B13",
+      "escalation_delay_in_minutes": 22,
+      "rule_object": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      },
+      "targets": [
+        {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        }
+      ]
+    },
+    {
+      "id": "PNTPYK0",
+      "escalation_delay_in_minutes": 10,
+      "rule_object": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      },
+      "targets": [
+        {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        }
+      ]
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/multi_update.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/multi_update.html
@@ -2,10 +2,160 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>Multi Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Multi Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT escalation_policies/:escalation_policy_id/escalation_rules</h1><p>Updates the entire collection of escalation rules for an existing escalation policy. The ordering is determined by the positions of each rule in the array. To create a new rule, add it to the array without an id. To remove a rule, do not include it in the array.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>An ordered array of escalation rules. The parameters can be found under the <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules API</a>.
-</td></tr></tbody></table></div><h3>Example</h3>
-<h3>Update all escalation rules</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{    &#x000A;      "escalation_rules": [&#x000A;        {&#x000A;          "escalation_delay_in_minutes": 12,&#x000A;          "targets": [&#x000A;            {&#x000A;              "type": "<span class='curl_params-type contenteditable' contenteditable='true'>schedule</span>",&#x000A;              "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PWEVPB6</span>"&#x000A;            }&#x000A;          ]&#x000A;        },&#x000A;        {&#x000A;          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PNTPYK0</span>",&#x000A;          "escalation_delay_in_minutes": 24&#x000A;        }&#x000A;      ]&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_rules&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PM3MXFU&quot;,&#x000A;      &quot;escalation_delay_in_minutes&quot;: 12,&#x000A;      &quot;rule_object&quot;: {&#x000A;        &quot;id&quot;: &quot;PWEVPB6&quot;,&#x000A;        &quot;name&quot;: &quot;Primary&quot;,&#x000A;        &quot;type&quot;: &quot;schedule&quot;&#x000A;      },&#x000A;      &quot;targets&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PWEVPB6&quot;,&#x000A;          &quot;name&quot;: &quot;Primary&quot;,&#x000A;          &quot;type&quot;: &quot;schedule&quot;&#x000A;        }&#x000A;      ]&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PNTPYK0&quot;,&#x000A;      &quot;escalation_delay_in_minutes&quot;: 24,&#x000A;      &quot;rule_object&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      },&#x000A;      &quot;targets&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        }&#x000A;      ]&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT escalation_policies/:escalation_policy_id/escalation_rules
+  </h1>
+  <p>
+    Updates the entire collection of escalation rules for an existing escalation policy. The ordering is determined by the positions of each rule in the array. To create a new rule, add it to the array without an id. To remove a rule, do not include it in the array.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            An ordered array of escalation rules. The parameters can be found under the <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules API</a>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Update all escalation rules
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{    
+      "escalation_rules": [
+        {
+          "escalation_delay_in_minutes": 12,
+          "targets": [
+            {
+              "type": "<span class='curl_params-type contenteditable' contenteditable='true'>schedule</span>",
+              "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PWEVPB6</span>"
+            }
+          ]
+        },
+        {
+          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PNTPYK0</span>",
+          "escalation_delay_in_minutes": 24
+        }
+      ]
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_rules": [
+    {
+      "id": "PM3MXFU",
+      "escalation_delay_in_minutes": 12,
+      "rule_object": {
+        "id": "PWEVPB6",
+        "name": "Primary",
+        "type": "schedule"
+      },
+      "targets": [
+        {
+          "id": "PWEVPB6",
+          "name": "Primary",
+          "type": "schedule"
+        }
+      ]
+    },
+    {
+      "id": "PNTPYK0",
+      "escalation_delay_in_minutes": 24,
+      "rule_object": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      },
+      "targets": [
+        {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        }
+      ]
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/show.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/show.html
@@ -2,21 +2,242 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET escalation_policies/:escalation_policy_id/escalation_rules/:id</h1><p>Show the escalation rule for an existing escalation policy.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Escalation Rule Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation rule.
-</td></tr><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The amount of time before an incident escalates away from this rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-An object representing the first target.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
-</td></tr></tbody></table></div><h3>Target Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The id of the target.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the target.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's email address.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's personal time zone.
-</td></tr><tr><td>color</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The color used to represent the user in schedules.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Get an escalation rule</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PNTPYK0</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PNTPYK0&quot;,&#x000A;    &quot;escalation_delay_in_minutes&quot;: 10,&#x000A;    &quot;rule_object&quot;: {&#x000A;      &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;      &quot;type&quot;: &quot;user&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;red&quot;&#x000A;    },&#x000A;    &quot;targets&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET escalation_policies/:escalation_policy_id/escalation_rules/:id
+  </h1>
+  <p>
+    Show the escalation rule for an existing escalation policy.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Escalation Rule Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The amount of time before an incident escalates away from this rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>An object representing the first target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The id of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's personal time zone.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            color
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The color used to represent the user in schedules.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get an escalation rule
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PNTPYK0</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_rule": {
+    "id": "PNTPYK0",
+    "escalation_delay_in_minutes": 10,
+    "rule_object": {
+      "id": "PPSFHH7",
+      "name": "Bob Smith",
+      "type": "user",
+      "email": "bob@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "red"
+    },
+    "targets": [
+      {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/escalation_rules/update.html
+++ b/source/documentation/rest/escalation_policies/escalation_rules/update.html
@@ -2,21 +2,315 @@
 title: PagerDuty Developer
 layout: main
 ---
-
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT escalation_policies/:escalation_policy_id/escalation_rules/:id</h1><p>Updates an escalation rule.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The escalation timeout in minutes. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>An object containing the <code>schedule</code> or <code>user</code> id and type.
-</td></tr></tbody></table></div><h3>Rule Object Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>A string of either <code>schedule</code> or <code>user</code>,
-</td></tr><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
-</td></tr></tbody></table></div><h3>Escalation Rule Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The escalation timeout in minutes. Must be at least <code>5</code> if the rule has multiple targets, and at least <code>1</code> if not. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-A single target. Ignored if <code>targets</code> is provided.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>The array of the targets an incident should be assigned to upon reaching this rule. Parameters detailed below.
-</td></tr></tbody></table></div><h3>Target Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>A string of either <code>schedule</code> or <code>user</code>,
-</td></tr><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Update an escalation rule</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"escalation_delay_in_minutes":44,"targets":[{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>schedule</span>","id":"<span class='curl_params-id contenteditable' contenteditable='true'>PWEVPB6</span>"}]}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PNTPYK0</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PNTPYK0&quot;,&#x000A;    &quot;escalation_delay_in_minutes&quot;: 44,&#x000A;    &quot;rule_object&quot;: {&#x000A;      &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;      &quot;type&quot;: &quot;user&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;red&quot;&#x000A;    },&#x000A;    &quot;targets&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT escalation_policies/:escalation_policy_id/escalation_rules/:id
+  </h1>
+  <p>
+    Updates an escalation rule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:escalation_policy_id</span>/escalation_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The escalation timeout in minutes. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            An object containing the <code>schedule</code> or <code>user</code> id and type.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Rule Object Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A string of either <code>schedule</code> or <code>user</code>,
+          </td>
+        </tr>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Rule Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The escalation timeout in minutes. Must be at least <code>5</code> if the rule has multiple targets, and at least <code>1</code> if not. If an incident is not acknowledged within this timeout then it will escalate onto the next escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>A single target. Ignored if <code>targets</code> is provided.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The array of the targets an incident should be assigned to upon reaching this rule. Parameters detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A string of either <code>schedule</code> or <code>user</code>,
+          </td>
+        </tr>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the <code>schedule</code> or <code>user</code> assigned to this rule.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Update an escalation rule
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"escalation_delay_in_minutes":44,"targets":[{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>schedule</span>","id":"<span class='curl_params-id contenteditable' contenteditable='true'>PWEVPB6</span>"}]}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-escalation_policy_id escalation_policy_id contenteditable" contenteditable="true">PBZ3BZV</span>/escalation_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PNTPYK0</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_rule": {
+    "id": "PNTPYK0",
+    "escalation_delay_in_minutes": 44,
+    "rule_object": {
+      "id": "PPSFHH7",
+      "name": "Bob Smith",
+      "type": "user",
+      "email": "bob@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "red"
+    },
+    "targets": [
+      {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "type": "user",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/index.html
+++ b/source/documentation/rest/escalation_policies/index.html
@@ -5,15 +5,75 @@ permalink: /documentation/rest/escalation_policies/
 redirect_from:
   - /documentation/rest/escalation_policies/escalation_policies.html
 ---
-                <ul class="breadcrumb">
-                  <li><a href="/documentation/rest">REST API</a></li>
-                  <span class="divider">/</span>
-                  <li>Escalation Policies</li>
-                </ul>
-                <div class='section'>
-                  <title></title>
-                  <h1 class="title">Escalation Policies API</h1>
-                  <table class="table action_index">
-                    <caption>This API lets you access and manipulate escalation policies and rules.</caption>
-                    <thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/escalation_policies/list">GET escalation_policies</a></td><td>List existing escalation policies.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/create">POST escalation_policies</a></td><td>Create a new escalation policy.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/show">GET escalation_policies/:id</a></td><td>Get details about an escalation policy.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/update">PUT escalation_policies/:id</a></td><td>Update an escalation policy.</td></tr><tr><td><a href="/documentation/rest/escalation_policies/delete">DELETE escalation_policies/:id</a></td><td>Delete an escalation policy.</td></tr>
-</tbody></table></div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Escalation Policies
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    Escalation Policies API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      This API lets you access and manipulate escalation policies and rules.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/list">GET escalation_policies</a>
+        </td>
+        <td>
+          List existing escalation policies.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/create">POST escalation_policies</a>
+        </td>
+        <td>
+          Create a new escalation policy.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/show">GET escalation_policies/:id</a>
+        </td>
+        <td>
+          Get details about an escalation policy.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/update">PUT escalation_policies/:id</a>
+        </td>
+        <td>
+          Update an escalation policy.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/escalation_policies/delete">DELETE escalation_policies/:id</a>
+        </td>
+        <td>
+          Delete an escalation policy.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/escalation_policies/list.html
+++ b/source/documentation/rest/escalation_policies/list.html
@@ -5,28 +5,479 @@ permalink: /documentation/rest/escalation_policies/list/
 redirect_from:
   - /documentation/rest/escalation_policies/list.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest/">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/">Escalation Policies</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest/">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET escalation_policies</h1><p>List all the existing escalation policies.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination/">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the result, showing only the escalation policies whose names match the query.
-</td></tr></tbody></table></div><h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>escalation_policies</td><td><a href="/documentation/rest/types#array">Array</a></td><td>The collection of escalation policies objects returned by the query. Fields detailed below.
-</td></tr></tbody></table></div><h3>Escalation Policy Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation policy.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the escalation policy.
-</td></tr><tr><td>num_loops</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The number of times the escalation policy will repeat after reaching the end of its escalation.
-</td></tr><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>A list of the policy's escalation rules in order of escalation. Fields detailed below.
-</td></tr><tr><td>services</td><td><a href="/documentation/rest/types#array">Array</a></td><td>A list of services using this escalation policy. See <a href="/documentation/rest/services/">Services</a> for the fields to expect.
-</td></tr></tbody></table></div><h3>Escalation Rule Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation rule.
-</td></tr><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The amount of time before an incident escalates away from this rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-An object representing the first target.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
-</td></tr></tbody></table></div><h3>Target Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The id of the target.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the target.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's email address.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's personal time zone.
-</td></tr><tr><td>color</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The color used to represent the user in schedules.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Get all escalation policies</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_policies&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKHHGIL&quot;,&#x000A;      &quot;name&quot;: &quot;Engineering Ops&quot;,&#x000A;      &quot;escalation_rules&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PSHOUAU&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 1,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;            &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;purple&quot;&#x000A;          },&#x000A;          &quot;targets&quot;: [&#x000A;            {&#x000A;              &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;              &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;              &quot;type&quot;: &quot;user&quot;,&#x000A;              &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;              &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;              &quot;color&quot;: &quot;purple&quot;&#x000A;            }&#x000A;          ]&#x000A;        },&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PP80TL4&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 30,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;            &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;red&quot;&#x000A;          },&#x000A;          &quot;targets&quot;: [&#x000A;            {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;type&quot;: &quot;user&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            }&#x000A;          ]&#x000A;        }&#x000A;      ],&#x000A;      &quot;services&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PPGAQ1X&quot;,&#x000A;          &quot;name&quot;: &quot;Server Check&quot;,&#x000A;          &quot;service_url&quot;: &quot;/services/PPGAQ1X&quot;,&#x000A;          &quot;service_key&quot;: &quot;server-check@pdt-samples.pagerduty.com&quot;,&#x000A;          &quot;auto_resolve_timeout&quot;: 14400,&#x000A;          &quot;acknowledgement_timeout&quot;: 1800,&#x000A;          &quot;created_at&quot;: &quot;2013-01-30T21:43:18-05:00&quot;,&#x000A;          &quot;deleted_at&quot;: null,&#x000A;          &quot;status&quot;: &quot;active&quot;,&#x000A;          &quot;last_incident_timestamp&quot;: &quot;2013-04-08T14:52:47-04:00&quot;,&#x000A;          &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;          &quot;incident_counts&quot;: {&#x000A;            &quot;triggered&quot;: 0,&#x000A;            &quot;acknowledged&quot;: 0,&#x000A;            &quot;resolved&quot;: 4,&#x000A;            &quot;total&quot;: 4&#x000A;          },&#x000A;          &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;          &quot;type&quot;: &quot;generic_email&quot;&#x000A;        }&#x000A;      ],&#x000A;      &quot;num_loops&quot;: 0,&#x000A;      &quot;description&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PBZ3BZV&quot;,&#x000A;      &quot;name&quot;: &quot;Escalation Policy&quot;,&#x000A;      &quot;escalation_rules&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PYO9B13&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 22,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;            &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;red&quot;&#x000A;          },&#x000A;          &quot;targets&quot;: [&#x000A;            {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;type&quot;: &quot;user&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            }&#x000A;          ]&#x000A;        }&#x000A;      ],&#x000A;      &quot;services&quot;: [&#x000A;&#x000A;      ],&#x000A;      &quot;num_loops&quot;: 2,&#x000A;      &quot;description&quot;: null&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 2&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET escalation_policies
+  </h1>
+  <p>
+    List all the existing escalation policies.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination/">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the escalation policies whose names match the query.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            escalation_policies
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            The collection of escalation policies objects returned by the query. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Policy Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            num_loops
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The number of times the escalation policy will repeat after reaching the end of its escalation.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            A list of the policy's escalation rules in order of escalation. Fields detailed below.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            services
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            A list of services using this escalation policy. See <a href="/documentation/rest/services/">Services</a> for the fields to expect.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Rule Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The amount of time before an incident escalates away from this rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>An object representing the first target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The id of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's personal time zone.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            color
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The color used to represent the user in schedules.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get all escalation policies
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_policies": [
+    {
+      "id": "PKHHGIL",
+      "name": "Engineering Ops",
+      "escalation_rules": [
+        {
+          "id": "PSHOUAU",
+          "escalation_delay_in_minutes": 1,
+          "rule_object": {
+            "id": "PT23IWX",
+            "name": "Tim Wright",
+            "type": "user",
+            "email": "tim@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "purple"
+          },
+          "targets": [
+            {
+              "id": "PT23IWX",
+              "name": "Tim Wright",
+              "type": "user",
+              "email": "tim@acme.com",
+              "time_zone": "Eastern Time (US &amp; Canada)",
+              "color": "purple"
+            }
+          ]
+        },
+        {
+          "id": "PP80TL4",
+          "escalation_delay_in_minutes": 30,
+          "rule_object": {
+            "id": "PPSFHH7",
+            "name": "Bob Smith",
+            "type": "user",
+            "email": "bob@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "red"
+          },
+          "targets": [
+            {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "type": "user",
+              "email": "bob@acme.com",
+              "time_zone": "Eastern Time (US &amp; Canada)",
+              "color": "red"
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "id": "PPGAQ1X",
+          "name": "Server Check",
+          "service_url": "/services/PPGAQ1X",
+          "service_key": "server-check@pdt-samples.pagerduty.com",
+          "auto_resolve_timeout": 14400,
+          "acknowledgement_timeout": 1800,
+          "created_at": "2013-01-30T21:43:18-05:00",
+          "deleted_at": null,
+          "status": "active",
+          "last_incident_timestamp": "2013-04-08T14:52:47-04:00",
+          "email_incident_creation": "on_new_email_subject",
+          "incident_counts": {
+            "triggered": 0,
+            "acknowledged": 0,
+            "resolved": 4,
+            "total": 4
+          },
+          "email_filter_mode": "all-email",
+          "type": "generic_email"
+        }
+      ],
+      "num_loops": 0,
+      "description": null
+    },
+    {
+      "id": "PBZ3BZV",
+      "name": "Escalation Policy",
+      "escalation_rules": [
+        {
+          "id": "PYO9B13",
+          "escalation_delay_in_minutes": 22,
+          "rule_object": {
+            "id": "PPSFHH7",
+            "name": "Bob Smith",
+            "type": "user",
+            "email": "bob@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "red"
+          },
+          "targets": [
+            {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "type": "user",
+              "email": "bob@acme.com",
+              "time_zone": "Eastern Time (US &amp; Canada)",
+              "color": "red"
+            }
+          ]
+        }
+      ],
+      "services": [
+
+      ],
+      "num_loops": 2,
+      "description": null
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 2
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/on_call.html
+++ b/source/documentation/rest/escalation_policies/on_call.html
@@ -2,11 +2,248 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/">Escalation Policies</a></li><span class="divider">/</span><li>On Call</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>On Call
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET escalation_policies/on_call</h1><p>List all the existing escalation policies with currently on-call users.</p>
-<p>If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/on_call</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the result, showing only the escalation policies whose names match the query.
-</td></tr></tbody></table></div><h3>Example</h3>
-<h3>Get an escalation rule</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/on_call"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_policies&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PAM4FGS&quot;,&#x000A;      &quot;name&quot;: &quot;All&quot;,&#x000A;      &quot;escalation_rules&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PZ8X4N7&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 30,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PEPV0NJ&quot;,&#x000A;            &quot;name&quot;: &quot;Cordell Simonis&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;simonis_cordell@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;dark-slate-blue&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;id&quot;: &quot;POQA264&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 34,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PF9KMXH&quot;,&#x000A;            &quot;name&quot;: &quot;Layered&quot;,&#x000A;            &quot;type&quot;: &quot;schedule&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;services&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;          &quot;name&quot;: &quot;Service Alpha&quot;,&#x000A;          &quot;integration_email&quot;: &quot;alpha@acme.pagerduty.dev&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pageduty.com/services/PBAZLIU&quot;,&#x000A;          &quot;escalation_policy_id&quot;: &quot;PAM4FGS&quot;&#x000A;        },&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;          &quot;name&quot;: &quot;Service Mail&quot;,&#x000A;          &quot;integration_email&quot;: &quot;email_1@acme.pagerduty.dev&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pageduty.com/services/PIJ90N7&quot;,&#x000A;          &quot;escalation_policy_id&quot;: &quot;PAM4FGS&quot;&#x000A;        }&#x000A;      ],&#x000A;      &quot;on_call&quot;: [&#x000A;        {&#x000A;          &quot;level&quot;: 1,&#x000A;          &quot;start&quot;: &quot;2014-03-03T20:00:00Z&quot;,&#x000A;          &quot;end&quot;: &quot;2014-03-07T20:00:00Z&quot;,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;P9TX7YH&quot;,&#x000A;            &quot;name&quot;: &quot;Cordell Simonis&quot;,&#x000A;            &quot;email&quot;: &quot;email_1@acme.pagerduty.dev&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Pacific Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;dark-goldenrod&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;level&quot;: 2,&#x000A;          &quot;start&quot;: &quot;2014-03-04T19:00:00Z&quot;,&#x000A;          &quot;end&quot;: &quot;2014-03-11T18:00:00Z&quot;,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;P5NKEIA&quot;,&#x000A;            &quot;name&quot;: &quot;John Smith&quot;,&#x000A;            &quot;email&quot;: &quot;jsmith@example.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Pacific Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;purple&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;num_loops&quot;: 0&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P29NBY9&quot;,&#x000A;      &quot;name&quot;: &quot;Beta&quot;,&#x000A;      &quot;escalation_rules&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PP3NI0M&quot;,&#x000A;          &quot;escalation_delay_in_minutes&quot;: 30,&#x000A;          &quot;rule_object&quot;: {&#x000A;            &quot;id&quot;: &quot;PF9KMXH&quot;,&#x000A;            &quot;name&quot;: &quot;Layered&quot;,&#x000A;            &quot;type&quot;: &quot;schedule&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;services&quot;: [&#x000A;        {&#x000A;          &quot;id&quot;: &quot;P2KFHAO&quot;,&#x000A;          &quot;name&quot;: &quot;BetaDense&quot;,&#x000A;          &quot;service_key&quot;: &quot;665ee8b4ab8446d1b7a8675b40047a2f&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pageduty.com/services/P2KFHAO&quot;,&#x000A;          &quot;escalation_policy_id&quot;: &quot;P29NBY9&quot;&#x000A;        },&#x000A;        {&#x000A;          &quot;id&quot;: &quot;PUS0KTE&quot;,&#x000A;          &quot;name&quot;: &quot;Note of Keys&quot;,&#x000A;          &quot;integration_email&quot;: &quot;note-of-keys@acme.pagerduty.com&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pageduty.com/services/PUS0KTE&quot;,&#x000A;          &quot;escalation_policy_id&quot;: &quot;P29NBY9&quot;&#x000A;        }&#x000A;      ],&#x000A;      &quot;on_call&quot;: [&#x000A;        {&#x000A;          &quot;level&quot;: 1,&#x000A;          &quot;start&quot;: &quot;2014-03-03T20:00:00Z&quot;,&#x000A;          &quot;end&quot;: &quot;2014-03-07T20:00:00Z&quot;,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;P9TX7YH&quot;,&#x000A;            &quot;name&quot;: &quot;John Smith&quot;,&#x000A;            &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Pacific Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;dark-goldenrod&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;level&quot;: 2,&#x000A;          &quot;start&quot;: &quot;2014-03-04T19:00:00Z&quot;,&#x000A;          &quot;end&quot;: &quot;2014-03-11T18:00:00Z&quot;,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;P5NKEIA&quot;,&#x000A;            &quot;name&quot;: &quot;Aliya Bradtke&quot;,&#x000A;            &quot;email&quot;: &quot;email_1@acme.pagerduty.dev&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Pacific Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;purple&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;level&quot;: 3,&#x000A;          &quot;start&quot;: null,&#x000A;          &quot;end&quot;: null,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;P3IMGZ3&quot;,&#x000A;            &quot;name&quot;: &quot;Aliya Bradtke&quot;,&#x000A;            &quot;email&quot;: &quot;email_1@acme.pagerduty.dev&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Pacific Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;brown&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;num_loops&quot;: 1&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 14&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET escalation_policies/on_call
+  </h1>
+  <p>
+    List all the existing escalation policies with currently on-call users.
+  </p>
+  <p>
+    If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/on_call
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the escalation policies whose names match the query.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get an escalation rule
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/on_call"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_policies": [
+    {
+      "id": "PAM4FGS",
+      "name": "All",
+      "escalation_rules": [
+        {
+          "id": "PZ8X4N7",
+          "escalation_delay_in_minutes": 30,
+          "rule_object": {
+            "id": "PEPV0NJ",
+            "name": "Cordell Simonis",
+            "type": "user",
+            "email": "simonis_cordell@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "dark-slate-blue"
+          }
+        },
+        {
+          "id": "POQA264",
+          "escalation_delay_in_minutes": 34,
+          "rule_object": {
+            "id": "PF9KMXH",
+            "name": "Layered",
+            "type": "schedule"
+          }
+        }
+      ],
+      "services": [
+        {
+          "id": "PBAZLIU",
+          "name": "Service Alpha",
+          "integration_email": "alpha@acme.pagerduty.dev",
+          "html_url": "https://acme.pageduty.com/services/PBAZLIU",
+          "escalation_policy_id": "PAM4FGS"
+        },
+        {
+          "id": "PIJ90N7",
+          "name": "Service Mail",
+          "integration_email": "email_1@acme.pagerduty.dev",
+          "html_url": "https://acme.pageduty.com/services/PIJ90N7",
+          "escalation_policy_id": "PAM4FGS"
+        }
+      ],
+      "on_call": [
+        {
+          "level": 1,
+          "start": "2014-03-03T20:00:00Z",
+          "end": "2014-03-07T20:00:00Z",
+          "user": {
+            "id": "P9TX7YH",
+            "name": "Cordell Simonis",
+            "email": "email_1@acme.pagerduty.dev",
+            "time_zone": "Pacific Time (US &amp; Canada)",
+            "color": "dark-goldenrod"
+          }
+        },
+        {
+          "level": 2,
+          "start": "2014-03-04T19:00:00Z",
+          "end": "2014-03-11T18:00:00Z",
+          "user": {
+            "id": "P5NKEIA",
+            "name": "John Smith",
+            "email": "jsmith@example.com",
+            "time_zone": "Pacific Time (US &amp; Canada)",
+            "color": "purple"
+          }
+        }
+      ],
+      "num_loops": 0
+    },
+    {
+      "id": "P29NBY9",
+      "name": "Beta",
+      "escalation_rules": [
+        {
+          "id": "PP3NI0M",
+          "escalation_delay_in_minutes": 30,
+          "rule_object": {
+            "id": "PF9KMXH",
+            "name": "Layered",
+            "type": "schedule"
+          }
+        }
+      ],
+      "services": [
+        {
+          "id": "P2KFHAO",
+          "name": "BetaDense",
+          "service_key": "665ee8b4ab8446d1b7a8675b40047a2f",
+          "html_url": "https://acme.pageduty.com/services/P2KFHAO",
+          "escalation_policy_id": "P29NBY9"
+        },
+        {
+          "id": "PUS0KTE",
+          "name": "Note of Keys",
+          "integration_email": "note-of-keys@acme.pagerduty.com",
+          "html_url": "https://acme.pageduty.com/services/PUS0KTE",
+          "escalation_policy_id": "P29NBY9"
+        }
+      ],
+      "on_call": [
+        {
+          "level": 1,
+          "start": "2014-03-03T20:00:00Z",
+          "end": "2014-03-07T20:00:00Z",
+          "user": {
+            "id": "P9TX7YH",
+            "name": "John Smith",
+            "email": "john@example.com",
+            "time_zone": "Pacific Time (US &amp; Canada)",
+            "color": "dark-goldenrod"
+          }
+        },
+        {
+          "level": 2,
+          "start": "2014-03-04T19:00:00Z",
+          "end": "2014-03-11T18:00:00Z",
+          "user": {
+            "id": "P5NKEIA",
+            "name": "Aliya Bradtke",
+            "email": "email_1@acme.pagerduty.dev",
+            "time_zone": "Pacific Time (US &amp; Canada)",
+            "color": "purple"
+          }
+        },
+        {
+          "level": 3,
+          "start": null,
+          "end": null,
+          "user": {
+            "id": "P3IMGZ3",
+            "name": "Aliya Bradtke",
+            "email": "email_1@acme.pagerduty.dev",
+            "time_zone": "Pacific Time (US &amp; Canada)",
+            "color": "brown"
+          }
+        }
+      ],
+      "num_loops": 1
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 14
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/show.html
+++ b/source/documentation/rest/escalation_policies/show.html
@@ -5,26 +5,324 @@ permalink: /documentation/rest/escalation_policies/show/
 redirect_from:
   - /documentation/rest/escalation_policies/show.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies">Escalation Policies</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET escalation_policies/:id</h1><p>Get information about an existing escalation policy and its rules.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Escalation Policy Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation policy.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the escalation policy.
-</td></tr><tr><td>num_loops</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The number of times the escalation policy will repeat after reaching the end of its escalation.
-</td></tr><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>A list of the policy's escalation rules in order of escalation. Fields detailed below.
-</td></tr><tr><td>services</td><td><a href="/documentation/rest/types#array">Array</a></td><td>A list of services using this escalation policy. See <a href="/documentation/rest/services">Services</a> for the fields to expect.
-</td></tr></tbody></table></div><h3>Escalation Rule Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The ID of the escalation rule.
-</td></tr><tr><td>escalation_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The amount of time before an incident escalates away from this rule.
-</td></tr><tr><td>rule_object</td><td><a href="/documentation/rest/types#object">Object</a></td><td><strong><div>This field is deprecated. See <i>targets</i> instead</div></strong>
-An object representing the first target.
-</td></tr><tr><td>targets</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
-</td></tr></tbody></table></div><h3>Target Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The id of the target.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the target.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's email address.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The user's personal time zone.
-</td></tr><tr><td>color</td><td><a href="/documentation/rest/types#string">String</a></td><td>Only for <code>user</code> targets. The color used to represent the user in schedules.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Get an escalation policy</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBZ3BZV</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_policy&quot;: {&#x000A;    &quot;id&quot;: &quot;PBZ3BZV&quot;,&#x000A;    &quot;name&quot;: &quot;Escalation Policy&quot;,&#x000A;    &quot;escalation_rules&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PYO9B13&quot;,&#x000A;        &quot;escalation_delay_in_minutes&quot;: 22,&#x000A;        &quot;rule_object&quot;: {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        },&#x000A;        &quot;targets&quot;: [&#x000A;          {&#x000A;            &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;            &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;red&quot;&#x000A;          }&#x000A;        ]&#x000A;      }&#x000A;    ],&#x000A;    &quot;services&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;num_loops&quot;: 2,&#x000A;    &quot;description&quot;: null&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET escalation_policies/:id
+  </h1>
+  <p>
+    Get information about an existing escalation policy and its rules.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Escalation Policy Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            num_loops
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The number of times the escalation policy will repeat after reaching the end of its escalation.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            A list of the policy's escalation rules in order of escalation. Fields detailed below.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            services
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            A list of services using this escalation policy. See <a href="/documentation/rest/services">Services</a> for the fields to expect.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Escalation Rule Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the escalation rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The amount of time before an incident escalates away from this rule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rule_object
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>targets</i> instead</strong>
+            </div>An object representing the first target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            targets
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of targets which an incident will be assigned to upon reaching this rule. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Target Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The id of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A representation of the type of the target. Will be either <code>schedule</code> or <code>user</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the target.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The user's personal time zone.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            color
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Only for <code>user</code> targets. The color used to represent the user in schedules.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get an escalation policy
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBZ3BZV</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_policy": {
+    "id": "PBZ3BZV",
+    "name": "Escalation Policy",
+    "escalation_rules": [
+      {
+        "id": "PYO9B13",
+        "escalation_delay_in_minutes": 22,
+        "rule_object": {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        },
+        "targets": [
+          {
+            "id": "PPSFHH7",
+            "name": "Bob Smith",
+            "type": "user",
+            "email": "bob@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "red"
+          }
+        ]
+      }
+    ],
+    "services": [
+
+    ],
+    "num_loops": 2,
+    "description": null
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/escalation_policies/update.html
+++ b/source/documentation/rest/escalation_policies/update.html
@@ -5,13 +5,173 @@ permalink: /documentation/rest/escalation_policies/update/
 redirect_from:
   - /documentation/rest/escalation_policies/update.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/escalation_policies/">Escalation Policies</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/escalation_policies/">Escalation Policies</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT escalation_policies/:id</h1><p>Updates an existing escalation policy and rules.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the escalation policy.
-</td></tr><tr><td>repeat_enabled</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>Whether or not to allow this policy to repeat its escalation rules after the last rule is finished.
-</td></tr><tr><td>num_loops</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The number of times to loop over the set of rules in this escalation policy.
-</td></tr><tr><td>escalation_rules</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>The escalation rules for this policy. The ordering and available parameters are found under the <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules API</a>.
-</td></tr></tbody></table></div><h3>Example</h3>
-<h3>Update an escalation policy</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>Escalation Policy 2</span>"}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBZ3BZV</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;escalation_policy&quot;: {&#x000A;    &quot;id&quot;: &quot;PBZ3BZV&quot;,&#x000A;    &quot;name&quot;: &quot;Escalation Policy 2&quot;,&#x000A;    &quot;escalation_rules&quot;: [&#x000A;      {&#x000A;        &quot;id&quot;: &quot;PYO9B13&quot;,&#x000A;        &quot;escalation_delay_in_minutes&quot;: 22,&#x000A;        &quot;rule_object&quot;: {&#x000A;          &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;          &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;          &quot;type&quot;: &quot;user&quot;,&#x000A;          &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;          &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;          &quot;color&quot;: &quot;red&quot;&#x000A;        },&#x000A;        &quot;targets&quot;: [&#x000A;          {&#x000A;            &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;            &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;,&#x000A;            &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;            &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;            &quot;color&quot;: &quot;red&quot;&#x000A;          }&#x000A;        ]&#x000A;      }&#x000A;    ],&#x000A;    &quot;services&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;num_loops&quot;: 2,&#x000A;    &quot;description&quot;: null&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT escalation_policies/:id
+  </h1>
+  <p>
+    Updates an existing escalation policy and rules.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/escalation_policies/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            repeat_enabled
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Whether or not to allow this policy to repeat its escalation rules after the last rule is finished.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            num_loops
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The number of times to loop over the set of rules in this escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_rules
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The escalation rules for this policy. The ordering and available parameters are found under the <a href="/documentation/rest/escalation_policies/escalation_rules">Escalation Rules API</a>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Update an escalation policy
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>Escalation Policy 2</span>"}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/escalation_policies/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBZ3BZV</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "escalation_policy": {
+    "id": "PBZ3BZV",
+    "name": "Escalation Policy 2",
+    "escalation_rules": [
+      {
+        "id": "PYO9B13",
+        "escalation_delay_in_minutes": 22,
+        "rule_object": {
+          "id": "PPSFHH7",
+          "name": "Bob Smith",
+          "type": "user",
+          "email": "bob@acme.com",
+          "time_zone": "Eastern Time (US &amp; Canada)",
+          "color": "red"
+        },
+        "targets": [
+          {
+            "id": "PPSFHH7",
+            "name": "Bob Smith",
+            "type": "user",
+            "email": "bob@acme.com",
+            "time_zone": "Eastern Time (US &amp; Canada)",
+            "color": "red"
+          }
+        ]
+      }
+    ],
+    "services": [
+
+    ],
+    "num_loops": 2,
+    "description": null
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/incidents/acknowledge.html
+++ b/source/documentation/rest/incidents/acknowledge.html
@@ -2,11 +2,77 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Acknowledge</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Acknowledge
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT incidents/:id/acknowledge</h1><p>Acknowledge an incident.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/acknowledge</pre></div><p>
-The status of this request will be 200 if the update succeeded.
-</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This will be added to the incident log entry.
-This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    PUT incidents/:id/acknowledge
+  </h1>
+  <p>
+    Acknowledge an incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/acknowledge
+</pre>
+  </div>
+  <p>
+    The status of this request will be 200 if the update succeeded.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This will be added to the incident log entry. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/incidents/count.html
+++ b/source/documentation/rest/incidents/count.html
@@ -2,40 +2,229 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Count</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Count
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET incidents/count</h1><p>
-Use this query if you are simply looking for the count of incidents that match a given query.
-This should be used if you don't need access to the actual incident details.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/count</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The start of the date range over which you want to search.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td><p>
-The end of the date range over which you want to search.
-</p>
-<p>
-<strong>NOTE:</strong> If you leave off either <code>since</code> or <code>until</code>, a 30 day default
-range is applied to your open ended range. Not including the
-<code>since</code> parameter will set the date range to <code>until</code> - 30 days. Likewise, if you leave off <code>until</code>, it
-is set to <code>since</code> + 30 days. Defaults to the last 30 days if you leave off both. The size of the date range must be less than 180 days.
-</p>
-</td></tr><tr><td>date_range</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>When set to <code>all</code>, the <code>since</code> and <code>until</code> parameters and defaults are ignored. Use this to get all counts since the account was created.
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Only counts the incidents currently in the passed status(es). Valid status options are <code>triggered</code>, <code>acknowledged</code>, and <code>resolved</code>. More status codes may be introduced in the future.</p>
-<p>Separate multiple statuses with a comma.</p>
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Only counts the incidents with the passed de-duplication key. See the
-<a href="/documentation/integration/events/">PagerDuty Integration API</a>
-docs for further details.
-</td></tr><tr><td>service</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Only counts the incidents associated with the passed service(s). This is expecting one or more service IDs.</p>
-<p>Separate multiple ids with a comma.</p>
-</td></tr><tr><td>assigned_to_user</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Only counts the incidents currently assigned to the passed user(s). This is expecting one or more user IDs.</p>
-<p>Note: When using the <code>assigned_to_user</code> filter, you will only count incidents with statuses of <code>triggered</code> or <code>acknowledged</code>. This is because <code>resolved</code> incidents are not assigned to any user.</p>
-<p>Separate multiple ids with a comma.</p>
-</td></tr></tbody></table></div><h2>Examples</h2>
-<h4>Fetch the total number of resolved incidents triggered over the last month.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/count"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;total&quot;: 2&#x000A;}</code></pre></div>
-<h4>
-Fetch the total number of incidents that are still open on service ID <code>PWP4EBH</code> that were triggered within the last month.
-</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \&#x000A;    --data-urlencode "service=<span class='curl_params-service contenteditable' contenteditable='true'>PWP4EBH</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/count"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;total&quot;: 15&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET incidents/count
+  </h1>
+  <p>
+    Use this query if you are simply looking for the count of incidents that match a given query. This should be used if you don't need access to the actual incident details.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/count
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The end of the date range over which you want to search.
+            </p>
+            <p>
+              <strong>NOTE:</strong> If you leave off either <code>since</code> or <code>until</code>, a 30 day default range is applied to your open ended range. Not including the <code>since</code> parameter will set the date range to <code>until</code> - 30 days. Likewise, if you leave off <code>until</code>, it is set to <code>since</code> + 30 days. Defaults to the last 30 days if you leave off both. The size of the date range must be less than 180 days.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            date_range
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            When set to <code>all</code>, the <code>since</code> and <code>until</code> parameters and defaults are ignored. Use this to get all counts since the account was created.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Only counts the incidents currently in the passed status(es). Valid status options are <code>triggered</code>, <code>acknowledged</code>, and <code>resolved</code>. More status codes may be introduced in the future.
+            </p>
+            <p>
+              Separate multiple statuses with a comma.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Only counts the incidents with the passed de-duplication key. See the <a href="/documentation/integration/events/">PagerDuty Integration API</a> docs for further details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Only counts the incidents associated with the passed service(s). This is expecting one or more service IDs.
+            </p>
+            <p>
+              Separate multiple ids with a comma.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Only counts the incidents currently assigned to the passed user(s). This is expecting one or more user IDs.
+            </p>
+            <p>
+              Note: When using the <code>assigned_to_user</code> filter, you will only count incidents with statuses of <code>triggered</code> or <code>acknowledged</code>. This is because <code>resolved</code> incidents are not assigned to any user.
+            </p>
+            <p>
+              Separate multiple ids with a comma.
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h4>
+    Fetch the total number of resolved incidents triggered over the last month.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/count"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "total": 2
+}</code>
+</pre>
+  </div>
+  <h4>
+    Fetch the total number of incidents that are still open on service ID <code>PWP4EBH</code> that were triggered within the last month.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \
+    --data-urlencode "service=<span class='curl_params-service contenteditable' contenteditable='true'>PWP4EBH</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/count"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "total": 15
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/incidents/index.html
+++ b/source/documentation/rest/incidents/index.html
@@ -5,44 +5,109 @@ permalink: /documentation/rest/incidents/
 redirect_from:
   - /documentation/rest/incidents.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Incidents</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Incidents
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Incidents API</h1>
-<p>
-<strong>
-Note that to create an incident you need to trigger it through the <a href="/documentation/integration/events/">events</a> API.
-</strong>
-</p>
-<p>
-PagerDuty receives updates (called <i>events</i>) from monitoring systems through services
-(like Nagios, email or generic API calls). Upon receiving an event, active services will create a
-new incident and begin escalating it as defined by the service's escalation policy.
-Events can be de-duplicated into existing incidents based on service de-duplication rules to prevent
-you from being overwhelmed by event storms.
-</p>
-<p>
-An incident can be open, acknowledged or resolved. Whenever an incident is created, it is assigned
-to a user (according to the escalation process, as described by escalation rules and
-<a href="/documentation/rest/schedules">schedules</a>).
-The assigned user has a chance to either acknowledge that he is working on it, or to resolve it.
-</p>
-<p>
-Resolving an incident closes it, whereas acknowledging it halts the escalation process.
-If the incident is not resolved by the service's <i>incident ack timeout</i> it continues up the escalation chain.
-</p>
-<p>
-When an incident is triggered or when it is escalated it creates
-<a href="/documentation/rest/alerts">alerts</a> (also known as <i>notifications</i>). Alerts are messages
-containing the details of the incident, and can be sent through SMS, email and phone calls.
-</p>
-<p>
-Incidents and Incident Counts from the last 30 days are returned by default. To change this default date range, see the documentation for the <code>since</code>, <code>until</code> or <code>date_range</code> parameters.
-</p>
-<table class="table action_index"><caption>This API lets you access and manipulate incidents.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/incidents/list">GET incidents</a></td><td>List existing incidents.</td></tr><tr><td><a href="/documentation/rest/incidents/show">GET incidents/:id</a></td><td>Show detailed information about an incident. Accepts either an incident id, or an incident number.</td></tr>
-<tr><td><a href="/documentation/rest/incidents/count">GET incidents/count</a></td><td>Count the number of incidents matching certain criteria.</td></tr>
-<tr><td><a href="/documentation/rest/incidents/update">PUT incidents</a></td><td>Acknowledge, resolve, escalate or reassign one or more incidents.</td></tr>
-<tr><td><a href="/documentation/rest/incidents/resolve">PUT incidents/:id/resolve</a></td><td>Resolve an incident.</td></tr>
-<tr><td><a href="/documentation/rest/incidents/acknowledge">PUT incidents/:id/acknowledge</a></td><td>Acknowledge an incident.</td></tr>
-<tr><td><a href="/documentation/rest/incidents/reassign">PUT incidents/:id/reassign</a></td><td>Reassign an incident.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Incidents API
+  </h1>
+  <p>
+    <strong>Note that to create an incident you need to trigger it through the <a href="/documentation/integration/events/">events</a> API.</strong>
+  </p>
+  <p>
+    PagerDuty receives updates (called <i>events</i>) from monitoring systems through services (like Nagios, email or generic API calls). Upon receiving an event, active services will create a new incident and begin escalating it as defined by the service's escalation policy. Events can be de-duplicated into existing incidents based on service de-duplication rules to prevent you from being overwhelmed by event storms.
+  </p>
+  <p>
+    An incident can be open, acknowledged or resolved. Whenever an incident is created, it is assigned to a user (according to the escalation process, as described by escalation rules and <a href="/documentation/rest/schedules">schedules</a>). The assigned user has a chance to either acknowledge that he is working on it, or to resolve it.
+  </p>
+  <p>
+    Resolving an incident closes it, whereas acknowledging it halts the escalation process. If the incident is not resolved by the service's <i>incident ack timeout</i> it continues up the escalation chain.
+  </p>
+  <p>
+    When an incident is triggered or when it is escalated it creates <a href="/documentation/rest/alerts">alerts</a> (also known as <i>notifications</i>). Alerts are messages containing the details of the incident, and can be sent through SMS, email and phone calls.
+  </p>
+  <p>
+    Incidents and Incident Counts from the last 30 days are returned by default. To change this default date range, see the documentation for the <code>since</code>, <code>until</code> or <code>date_range</code> parameters.
+  </p>
+  <table class="table action_index">
+    <caption>
+      This API lets you access and manipulate incidents.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/list">GET incidents</a>
+        </td>
+        <td>
+          List existing incidents.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/show">GET incidents/:id</a>
+        </td>
+        <td>
+          Show detailed information about an incident. Accepts either an incident id, or an incident number.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/count">GET incidents/count</a>
+        </td>
+        <td>
+          Count the number of incidents matching certain criteria.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/update">PUT incidents</a>
+        </td>
+        <td>
+          Acknowledge, resolve, escalate or reassign one or more incidents.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/resolve">PUT incidents/:id/resolve</a>
+        </td>
+        <td>
+          Resolve an incident.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/acknowledge">PUT incidents/:id/acknowledge</a>
+        </td>
+        <td>
+          Acknowledge an incident.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/reassign">PUT incidents/:id/reassign</a>
+        </td>
+        <td>
+          Reassign an incident.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/incidents/list.html
+++ b/source/documentation/rest/incidents/list.html
@@ -2,121 +2,784 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest/">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents/">Incidents</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest/">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents/">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET incidents</h1><p>
-The PagerDuty incidents query API can be used to query current and historical PagerDuty incidents over a date range, letting you build custom dashboards or incident reports. The API allows for searching for incidents with multiple filters or query parameters, various sorts, and also supports the pagination of results.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The start of the date range over which you want to search.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td><p>
-The end of the date range over which you want to search.
-</p>
-<p>
-<strong>NOTE:</strong> If you leave off either <code>since</code> or <code>until</code>, a 30 day default
-range is applied to your open ended range. Not including the
-<code>since</code> parameter will set the date range to <code>until</code> - 30 days. Likewise, if you leave off <code>until</code>, it
-is set to <code>since</code> + 30 days. Defaults to the last 30 days if you leave off both. The size of the date range must be less than 180 days.
-</p>
-</td></tr><tr><td>date_range</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>When set to <code>all</code>, the <code>since</code> and <code>until</code> parameters and defaults are ignored. Use this to get all incidents since the account was created.
-</td></tr><tr><td>fields</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Used to restrict the properties of each incident returned to a set of pre-defined fields. If omitted, returned incidents have all fields present. See below for a list of possible fields.
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Returns only the incidents currently in the passed status(es). Valid status options are <code>triggered</code>, <code>acknowledged</code>, and <code>resolved</code>. More status codes may be introduced in the future.</p>
-<p>Separate multiple statuses with a comma.</p>
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Returns only the incidents with the passed de-duplication key. See the
-<a href="/documentation/integration/events">PagerDuty Integration API</a>
-docs for further details.
-</td></tr><tr><td>service</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Returns only the incidents associated with the passed service(s). This expects one or more service IDs.</p>
-<p>Separate multiple ids with a comma.</p>
-</td></tr><tr><td>assigned_to_user</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>Returns only the incidents currently assigned to the passed user(s). This expects one or more user IDs. Please see below for more info on how to find your users' IDs.</p>
-<p>Note: When using the <code>assigned_to_user</code> filter, you will only receive incidents with statuses of <code>triggered</code> or <code>acknowledged</code>. This is because <code>resolved</code> incidents are not assigned to any user.</p>
-<p>Separate multiple ids with a comma.</p>
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>.
-</td></tr><tr><td>sort_by</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Used to specify both the field you wish to sort the results on, as well as the direction (ascending/descending) of the results.
-<ul>
-<li><code>incident_number</code> The number of your incident.</li>
-<li><code>created_on</code> The date/time the incident was triggered.</li>
-<li><code>resolved_on</code> The date/time the incident was resolved.</li>
-</ul>
-<p>
-Valid values for the <code>sort_by</code> direction are:
-</p>
-<ul>
-<li><code>asc</code> This sorts ascending (default if omitted).</li>
-<li><code>desc</code> This sorts descending.</li>
-</ul>
-<p>
-The sort_by field and direction should be separated by a colon.
-</p>
-<p>
-Example: to sort by the most-recently-created incidents, include the query parameter:
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;sort_by&quot;: &quot;created_on:desc&quot;&#x000A;}</code></pre>
-</td></tr></tbody></table></div><h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>incident_number</td><td><a href="/documentation/rest/types#string">String</a></td><td>The number of the incident. This is unique across your account.
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>The current status of the incident. Valid statuses are:
-<ul>
-<li><code>triggered</code> The incident is in alarm and is assigned to a user, and is not currently acknowledged.</li>
-<li><code>acknowledged</code> The incident is in alarm and is assigned to a user, but has been already acknowledged (via phone, SMS, or PagerDuty website).</li>
-<li><code>resolved</code> The incident is no longer in alarm and has been resolved (manually or automatically).</li>
-<strong>NOTE:</strong>
-We anticipate the need for introducing new status codes in the future. Please build your client code to handle unknown status codes gracefully.
-</ul>
-</td></tr><tr><td>created_on</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The date/time the incident was triggered.
-</td></tr><tr><td>html_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>The PagerDuty website URL where the incident can be viewed and further actions taken. This is <strong>not</strong> the resource URL.
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>The incident's de-duplication key. See the <a href="/documentation/integration/events">PagerDuty Integration API</a> docs for further details.
-</td></tr><tr><td>service</td><td><a href="/documentation/rest/types#object">Object</a></td><td>The PagerDuty service that the incident belongs to. The service will contain fields of its own.
-</td></tr><tr><td>escalation_policy</td><td><a href="/documentation/rest/types#object">Object</a></td><td>The escalation policy that the incident belongs to. The policy will contain fields of its own.
-</td></tr><tr><td>assigned_to</td><td><a href="/documentation/rest/types#array">Array</a></td><td><p>
-The list of <i>assignments</i> of the incident. An <i>assignment</i> is an object containing the assigned user as well as the date/time the incident was assigned to that user.
-The user will contain fields of its own. This list is empty if the status of the incident is <code>resolved</code>.
-</p>
-<p>
-<strong>NOTE:</strong>
-The assigned user of an <i>assignment</i> is accessible through the <code>object</code> field, which will have the fields of the user plus a <code>type</code> field.
-Currently, the <code>type</code> field will always be <code>user</code>.
-We may add new <code>type</code>s in the future. Please build your client code to handle unknown types gracefully.
-</p>
-<p>
-Example: <code>assigned_to</code> field for an incident assigned to two users.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;assigned_to&quot;: [&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2014-01-01T08:00:00Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;id&quot;: &quot;PMI6007&quot;,&#x000A;        &quot;name&quot;: &quot;James&quot;,&#x000A;        &quot;email&quot;: &quot;james@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PMI6007&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2014-01-01T08:00:00Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;id&quot;: &quot;BH90210&quot;,&#x000A;        &quot;name&quot;: &quot;Dylan&quot;,&#x000A;        &quot;email&quot;: &quot;dylan@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/BH90210&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      }&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>assigned_to_user</td><td><a href="/documentation/rest/types#object">Object</a></td><td><strong><div>This field is deprecated. See <i>assigned_to</i> instead.</div></strong>
-A user that the incident is currently assigned to, if the incident is not currently in the resolved state and is assigned to a user. The user will have fields of its own. If an incident is assigned to multiple users, this field will contain only the first assigned user.
-</td></tr><tr><td>acknowledgers</td><td><a href="/documentation/rest/types#array">Array</a></td><td><p>
-The list of <i>acknowledgements</i> of the incident. An <i>acknowledgement</i> is an object containing the acknowleding object (either a user or the integration API) as well as the date/time the incident was acknowledged.
-This field is only present if the status of the incident is <code>acknowledged</code>. This field is sorted in ascending order by acknowledgement time.
-</p>
-<p>
-Example: <code>acknowledgers</code> field for an incident first acknowledged by a user, then by the integration API.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;acknowledgers&quot;: [&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2014-01-01T09:00:00Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;id&quot;: &quot;PEO3O45&quot;,&#x000A;        &quot;name&quot;: &quot;John&quot;,&#x000A;        &quot;email&quot;: &quot;john@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PEO3O45&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2014-01-01T10:05:00Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;type&quot;: &quot;api&quot;&#x000A;      }&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>last_status_change_by</td><td><a href="/documentation/rest/types#object">Object</a></td><td>The user who is responsible for the incident's last status change. If the incident is in the acknowledged or resolved status, this will be the user that took the first acknowledged or resolved action. If the incident was automatically resolved (say through the Event Integration API), or if the incident is in the triggered state, this will be null. User fields are the same as in the assigned_to_user field above.
-</td></tr><tr><td>last_status_change_on</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The date/time the incident's status last changed.
-</td></tr><tr><td>trigger_summary_data</td><td><a href="/documentation/rest/types#object">Object</a></td><td><p>
-Some condensed information regarding the initial event that triggered this incident. This data will be a set of key/value pairs that vary depending on what sort of event triggered the incident (email, Event API request, etc). For instance, if an email triggered the incident, then the <code>trigger_summary_data</code> will likely contain a <code>subject</code>. There are no guarantees on the full presence of this data for every incident.
-</p>
-</td></tr><tr><td>trigger_details_html_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>The PagerDuty website URL where the full details regarding the initial event that triggered this incident can be found. (This is <strong>not</strong> the resource URL.)
-</td></tr></tbody></table></div><h2>Examples</h2>
-<h4>Get all triggered and acknowledged incidents</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;incidents&quot;: [&#x000A;    {&#x000A;      &quot;incident_number&quot;: 1,&#x000A;      &quot;created_on&quot;: &quot;2012-09-11T22:49:21Z&quot;,&#x000A;      &quot;status&quot;: &quot;triggered&quot;,&#x000A;      &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/P2A6J96&quot;,&#x000A;      &quot;incident_key&quot;: null,&#x000A;      &quot;service&quot;: {&#x000A;        &quot;id&quot;: &quot;PBF77WY&quot;,&#x000A;        &quot;name&quot;: &quot;Generic Api&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PBF77WY&quot;&#x000A;      },&#x000A;      &quot;assigned_to_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PEO3O45&quot;,&#x000A;        &quot;name&quot;: &quot;John&quot;,&#x000A;        &quot;email&quot;: &quot;john@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PEO3O45&quot;&#x000A;      },&#x000A;      &quot;assigned_to&quot;: [&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T22:49:21Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;id&quot;: &quot;PEO3O45&quot;,&#x000A;            &quot;name&quot;: &quot;John&quot;,&#x000A;            &quot;email&quot;: &quot;john@acme.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PEO3O45&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;trigger_summary_data&quot;: {&#x000A;        &quot;subject&quot;: &quot;Opened on the web ui&quot;&#x000A;      },&#x000A;      &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/P2A6J96/log_entries/P2NQP6P&quot;,&#x000A;      &quot;last_status_change_on&quot;: &quot;2012-09-11T22:49:21Z&quot;,&#x000A;      &quot;last_status_change_by&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;incident_number&quot;: 3,&#x000A;      &quot;created_on&quot;: &quot;2012-09-11T22:54:08Z&quot;,&#x000A;      &quot;status&quot;: &quot;acknowledged&quot;,&#x000A;      &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PBXG6JS&quot;,&#x000A;      &quot;incident_key&quot;: &quot;=?UTF-8?B?SnVzdCBhbiBlbWFpbCBmcm9tIOWvjOWjq+WxsSBhbmQg8J2EnvCdlaXwnZ+2IPCggoo=?=&quot;,&#x000A;      &quot;service&quot;: {&#x000A;        &quot;id&quot;: &quot;PFRV88L&quot;,&#x000A;        &quot;name&quot;: &quot;Generic Email&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PFRV88L&quot;&#x000A;      },&#x000A;      &quot;assigned_to_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PEO3O45&quot;,&#x000A;        &quot;name&quot;: &quot;John&quot;,&#x000A;        &quot;email&quot;: &quot;john@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PEO3O45&quot;&#x000A;      },&#x000A;      &quot;assigned_to&quot;: [&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T22:54:08Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;id&quot;: &quot;PEO3O45&quot;,&#x000A;            &quot;name&quot;: &quot;John&quot;,&#x000A;            &quot;email&quot;: &quot;john@acme.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PEO3O45&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T22:54:08Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;id&quot;: &quot;PMI6007&quot;,&#x000A;            &quot;name&quot;: &quot;James&quot;,&#x000A;            &quot;email&quot;: &quot;james@acme.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PMI6007&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;acknowledgers&quot;: [&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T22:55:01Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;id&quot;: &quot;PMI6007&quot;,&#x000A;            &quot;name&quot;: &quot;James&quot;,&#x000A;            &quot;email&quot;: &quot;james@acme.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PMI6007&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T22:55:32Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;type&quot;: &quot;api&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;at&quot;: &quot;2012-09-11T23:25:49Z&quot;,&#x000A;          &quot;object&quot;: {&#x000A;            &quot;id&quot;: &quot;PMI6007&quot;,&#x000A;            &quot;name&quot;: &quot;James&quot;,&#x000A;            &quot;email&quot;: &quot;james@acme.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PMI6007&quot;,&#x000A;            &quot;type&quot;: &quot;user&quot;&#x000A;          }&#x000A;        }&#x000A;      ],&#x000A;      &quot;trigger_summary_data&quot;: {&#x000A;        &quot;subject&quot;: &quot;Just an email from 富士山 and 𝄞𝕥𝟶 𠂊&quot;&#x000A;      },&#x000A;      &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PBXG6JS/log_entries/P30IVAT&quot;,&#x000A;      &quot;last_status_change_on&quot;: &quot;2012-09-11T22:55:01Z&quot;,&#x000A;      &quot;last_status_change_by&quot;: {&#x000A;        &quot;id&quot;: &quot;PMI6007&quot;,&#x000A;        &quot;name&quot;: &quot;James&quot;,&#x000A;        &quot;email&quot;: &quot;james@acme.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PMI6007&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 2&#x000A;}</code></pre></div>
-<h4>Get only the incident_number and the status of all incidents.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "fields=<span class='curl_params-fields contenteditable' contenteditable='true'>incident_number,status</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;incidents&quot;: [&#x000A;    {&#x000A;      &quot;incident_number&quot;: 1,&#x000A;      &quot;status&quot;: &quot;resolved&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;incident_number&quot;: 2,&#x000A;      &quot;status&quot;: &quot;triggered&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;incident_number&quot;: 3,&#x000A;      &quot;status&quot;: &quot;resolved&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;incident_number&quot;: 4,&#x000A;      &quot;status&quot;: &quot;triggered&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;incident_number&quot;: 5,&#x000A;      &quot;status&quot;: &quot;triggered&quot;&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 5&#x000A;}</code></pre></div>
-<p>Below are some examples of Incident Query API requests.</p>
-<p>In all examples, the (fake) PagerDuty account subdomain used is <code>acme</code> and the current date is 2011-05-01.</p>
-<h4>Fetch the 100 most recent incidents triggered across the entire <code>acme</code> account within the last 3 months.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>Fetch the 50 most recent incidents triggered within the last 3 months.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \&#x000A;    --data-urlencode "limit=50" \&#x000A;    --data-urlencode "offset=0" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>Fetch the second page of 50 most recent incidents triggered within the last 3 months.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \&#x000A;    --data-urlencode "limit=50" \&#x000A;    --data-urlencode "offset=50" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>
-Fetch the first page of incidents for service ID <code>PWP4EBH</code> within the last month.
-</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "service=<span class='curl_params-service contenteditable' contenteditable='true'>PWP4EBH</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>Fetch the first page of resolved incidents that were triggered within the last month.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>resolved_on:asc</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>Fetch the first page of incidents that are not yet resolved but are greater than 1 week old.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-01-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-04-24</span>" \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:asc</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
-<h4>For the 20 most recent still-unresolved incidents this last month, fetch just the list of users whom they're assigned to and the corresponding incident HTML URLs (so, for instance, you can email them and remind them about their open incidents and link to them).</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \&#x000A;    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \&#x000A;    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \&#x000A;    --data-urlencode "limit=20" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre>
+  <h1 class="title">
+    GET incidents
+  </h1>
+  <p>
+    The PagerDuty incidents query API can be used to query current and historical PagerDuty incidents over a date range, letting you build custom dashboards or incident reports. The API allows for searching for incidents with multiple filters or query parameters, various sorts, and also supports the pagination of results.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The end of the date range over which you want to search.
+            </p>
+            <p>
+              <strong>NOTE:</strong> If you leave off either <code>since</code> or <code>until</code>, a 30 day default range is applied to your open ended range. Not including the <code>since</code> parameter will set the date range to <code>until</code> - 30 days. Likewise, if you leave off <code>until</code>, it is set to <code>since</code> + 30 days. Defaults to the last 30 days if you leave off both. The size of the date range must be less than 180 days.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            date_range
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            When set to <code>all</code>, the <code>since</code> and <code>until</code> parameters and defaults are ignored. Use this to get all incidents since the account was created.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            fields
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Used to restrict the properties of each incident returned to a set of pre-defined fields. If omitted, returned incidents have all fields present. See below for a list of possible fields.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Returns only the incidents currently in the passed status(es). Valid status options are <code>triggered</code>, <code>acknowledged</code>, and <code>resolved</code>. More status codes may be introduced in the future.
+            </p>
+            <p>
+              Separate multiple statuses with a comma.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Returns only the incidents with the passed de-duplication key. See the <a href="/documentation/integration/events">PagerDuty Integration API</a> docs for further details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Returns only the incidents associated with the passed service(s). This expects one or more service IDs.
+            </p>
+            <p>
+              Separate multiple ids with a comma.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Returns only the incidents currently assigned to the passed user(s). This expects one or more user IDs. Please see below for more info on how to find your users' IDs.
+            </p>
+            <p>
+              Note: When using the <code>assigned_to_user</code> filter, you will only receive incidents with statuses of <code>triggered</code> or <code>acknowledged</code>. This is because <code>resolved</code> incidents are not assigned to any user.
+            </p>
+            <p>
+              Separate multiple ids with a comma.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            sort_by
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Used to specify both the field you wish to sort the results on, as well as the direction (ascending/descending) of the results.
+            <ul>
+              <li>
+                <code>incident_number</code> The number of your incident.
+              </li>
+              <li>
+                <code>created_on</code> The date/time the incident was triggered.
+              </li>
+              <li>
+                <code>resolved_on</code> The date/time the incident was resolved.
+              </li>
+            </ul>
+            <p>
+              Valid values for the <code>sort_by</code> direction are:
+            </p>
+            <ul>
+              <li>
+                <code>asc</code> This sorts ascending (default if omitted).
+              </li>
+              <li>
+                <code>desc</code> This sorts descending.
+              </li>
+            </ul>
+            <p>
+              The sort_by field and direction should be separated by a colon.
+            </p>
+            <p>
+              Example: to sort by the most-recently-created incidents, include the query parameter:
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "sort_by": "created_on:desc"
+}</code>
+</pre>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            incident_number
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The number of the incident. This is unique across your account.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The current status of the incident. Valid statuses are:
+            <ul>
+              <li>
+                <code>triggered</code> The incident is in alarm and is assigned to a user, and is not currently acknowledged.
+              </li>
+              <li>
+                <code>acknowledged</code> The incident is in alarm and is assigned to a user, but has been already acknowledged (via phone, SMS, or PagerDuty website).
+              </li>
+              <li>
+                <code>resolved</code> The incident is no longer in alarm and has been resolved (manually or automatically).
+              </li>
+              <li style="list-style: none">
+                <strong>NOTE:</strong> We anticipate the need for introducing new status codes in the future. Please build your client code to handle unknown status codes gracefully.
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            created_on
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The date/time the incident was triggered.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            html_url
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The PagerDuty website URL where the incident can be viewed and further actions taken. This is <strong>not</strong> the resource URL.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The incident's de-duplication key. See the <a href="/documentation/integration/events">PagerDuty Integration API</a> docs for further details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            The PagerDuty service that the incident belongs to. The service will contain fields of its own.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            The escalation policy that the incident belongs to. The policy will contain fields of its own.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            <p>
+              The list of <i>assignments</i> of the incident. An <i>assignment</i> is an object containing the assigned user as well as the date/time the incident was assigned to that user. The user will contain fields of its own. This list is empty if the status of the incident is <code>resolved</code>.
+            </p>
+            <p>
+              <strong>NOTE:</strong> The assigned user of an <i>assignment</i> is accessible through the <code>object</code> field, which will have the fields of the user plus a <code>type</code> field. Currently, the <code>type</code> field will always be <code>user</code>. We may add new <code>type</code>s in the future. Please build your client code to handle unknown types gracefully.
+            </p>
+            <p>
+              Example: <code>assigned_to</code> field for an incident assigned to two users.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "assigned_to": [
+    {
+      "at": "2014-01-01T08:00:00Z",
+      "object": {
+        "id": "PMI6007",
+        "name": "James",
+        "email": "james@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/PMI6007",
+        "type": "user"
+      }
+    },
+    {
+      "at": "2014-01-01T08:00:00Z",
+      "object": {
+        "id": "BH90210",
+        "name": "Dylan",
+        "email": "dylan@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/BH90210",
+        "type": "user"
+      }
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <div>
+              <strong>This field is deprecated. See <i>assigned_to</i> instead.</strong>
+            </div>A user that the incident is currently assigned to, if the incident is not currently in the resolved state and is assigned to a user. The user will have fields of its own. If an incident is assigned to multiple users, this field will contain only the first assigned user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            acknowledgers
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            <p>
+              The list of <i>acknowledgements</i> of the incident. An <i>acknowledgement</i> is an object containing the acknowleding object (either a user or the integration API) as well as the date/time the incident was acknowledged. This field is only present if the status of the incident is <code>acknowledged</code>. This field is sorted in ascending order by acknowledgement time.
+            </p>
+            <p>
+              Example: <code>acknowledgers</code> field for an incident first acknowledged by a user, then by the integration API.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "acknowledgers": [
+    {
+      "at": "2014-01-01T09:00:00Z",
+      "object": {
+        "id": "PEO3O45",
+        "name": "John",
+        "email": "john@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/PEO3O45",
+        "type": "user"
+      }
+    },
+    {
+      "at": "2014-01-01T10:05:00Z",
+      "object": {
+        "type": "api"
+      }
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            last_status_change_by
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            The user who is responsible for the incident's last status change. If the incident is in the acknowledged or resolved status, this will be the user that took the first acknowledged or resolved action. If the incident was automatically resolved (say through the Event Integration API), or if the incident is in the triggered state, this will be null. User fields are the same as in the assigned_to_user field above.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            last_status_change_on
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The date/time the incident's status last changed.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            trigger_summary_data
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            <p>
+              Some condensed information regarding the initial event that triggered this incident. This data will be a set of key/value pairs that vary depending on what sort of event triggered the incident (email, Event API request, etc). For instance, if an email triggered the incident, then the <code>trigger_summary_data</code> will likely contain a <code>subject</code>. There are no guarantees on the full presence of this data for every incident.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            trigger_details_html_url
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The PagerDuty website URL where the full details regarding the initial event that triggered this incident can be found. (This is <strong>not</strong> the resource URL.)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h4>
+    Get all triggered and acknowledged incidents
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "incidents": [
+    {
+      "incident_number": 1,
+      "created_on": "2012-09-11T22:49:21Z",
+      "status": "triggered",
+      "html_url": "https://acme.pagerduty.com/incidents/P2A6J96",
+      "incident_key": null,
+      "service": {
+        "id": "PBF77WY",
+        "name": "Generic Api",
+        "html_url": "https://acme.pagerduty.com/services/PBF77WY"
+      },
+      "assigned_to_user": {
+        "id": "PEO3O45",
+        "name": "John",
+        "email": "john@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/PEO3O45"
+      },
+      "assigned_to": [
+        {
+          "at": "2012-09-11T22:49:21Z",
+          "object": {
+            "id": "PEO3O45",
+            "name": "John",
+            "email": "john@acme.com",
+            "html_url": "https://acme.pagerduty.com/users/PEO3O45",
+            "type": "user"
+          }
+        }
+      ],
+      "trigger_summary_data": {
+        "subject": "Opened on the web ui"
+      },
+      "trigger_details_html_url": "https://acme.pagerduty.com/incidents/P2A6J96/log_entries/P2NQP6P",
+      "last_status_change_on": "2012-09-11T22:49:21Z",
+      "last_status_change_by": null
+    },
+    {
+      "incident_number": 3,
+      "created_on": "2012-09-11T22:54:08Z",
+      "status": "acknowledged",
+      "html_url": "https://acme.pagerduty.com/incidents/PBXG6JS",
+      "incident_key": "=?UTF-8?B?SnVzdCBhbiBlbWFpbCBmcm9tIOWvjOWjq+WxsSBhbmQg8J2EnvCdlaXwnZ+2IPCggoo=?=",
+      "service": {
+        "id": "PFRV88L",
+        "name": "Generic Email",
+        "html_url": "https://acme.pagerduty.com/services/PFRV88L"
+      },
+      "assigned_to_user": {
+        "id": "PEO3O45",
+        "name": "John",
+        "email": "john@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/PEO3O45"
+      },
+      "assigned_to": [
+        {
+          "at": "2012-09-11T22:54:08Z",
+          "object": {
+            "id": "PEO3O45",
+            "name": "John",
+            "email": "john@acme.com",
+            "html_url": "https://acme.pagerduty.com/users/PEO3O45",
+            "type": "user"
+          }
+        },
+        {
+          "at": "2012-09-11T22:54:08Z",
+          "object": {
+            "id": "PMI6007",
+            "name": "James",
+            "email": "james@acme.com",
+            "html_url": "https://acme.pagerduty.com/users/PMI6007",
+            "type": "user"
+          }
+        }
+      ],
+      "acknowledgers": [
+        {
+          "at": "2012-09-11T22:55:01Z",
+          "object": {
+            "id": "PMI6007",
+            "name": "James",
+            "email": "james@acme.com",
+            "html_url": "https://acme.pagerduty.com/users/PMI6007",
+            "type": "user"
+          }
+        },
+        {
+          "at": "2012-09-11T22:55:32Z",
+          "object": {
+            "type": "api"
+          }
+        },
+        {
+          "at": "2012-09-11T23:25:49Z",
+          "object": {
+            "id": "PMI6007",
+            "name": "James",
+            "email": "james@acme.com",
+            "html_url": "https://acme.pagerduty.com/users/PMI6007",
+            "type": "user"
+          }
+        }
+      ],
+      "trigger_summary_data": {
+        "subject": "Just an email from 富士山 and 𝄞𝕥𝟶 𠂊"
+      },
+      "trigger_details_html_url": "https://acme.pagerduty.com/incidents/PBXG6JS/log_entries/P30IVAT",
+      "last_status_change_on": "2012-09-11T22:55:01Z",
+      "last_status_change_by": {
+        "id": "PMI6007",
+        "name": "James",
+        "email": "james@acme.com",
+        "html_url": "https://acme.pagerduty.com/users/PMI6007"
+      }
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 2
+}</code>
+</pre>
+  </div>
+  <h4>
+    Get only the incident_number and the status of all incidents.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "fields=<span class='curl_params-fields contenteditable' contenteditable='true'>incident_number,status</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "incidents": [
+    {
+      "incident_number": 1,
+      "status": "resolved"
+    },
+    {
+      "incident_number": 2,
+      "status": "triggered"
+    },
+    {
+      "incident_number": 3,
+      "status": "resolved"
+    },
+    {
+      "incident_number": 4,
+      "status": "triggered"
+    },
+    {
+      "incident_number": 5,
+      "status": "triggered"
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 5
+}</code>
+</pre>
+  </div>
+  <p>
+    Below are some examples of Incident Query API requests.
+  </p>
+  <p>
+    In all examples, the (fake) PagerDuty account subdomain used is <code>acme</code> and the current date is 2011-05-01.
+  </p>
+  <h4>
+    Fetch the 100 most recent incidents triggered across the entire <code>acme</code> account within the last 3 months.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Fetch the 50 most recent incidents triggered within the last 3 months.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \
+    --data-urlencode "limit=50" \
+    --data-urlencode "offset=0" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Fetch the second page of 50 most recent incidents triggered within the last 3 months.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-02-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \
+    --data-urlencode "limit=50" \
+    --data-urlencode "offset=50" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Fetch the first page of incidents for service ID <code>PWP4EBH</code> within the last month.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "service=<span class='curl_params-service contenteditable' contenteditable='true'>PWP4EBH</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Fetch the first page of resolved incidents that were triggered within the last month.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>resolved_on:asc</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Fetch the first page of incidents that are not yet resolved but are greater than 1 week old.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-01-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-04-24</span>" \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:asc</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    For the 20 most recent still-unresolved incidents this last month, fetch just the list of users whom they're assigned to and the corresponding incident HTML URLs (so, for instance, you can email them and remind them about their open incidents and link to them).
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-04-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-05-01</span>" \
+    --data-urlencode "status=<span class='curl_params-status contenteditable' contenteditable='true'>triggered,acknowledged</span>" \
+    --data-urlencode "sort_by=<span class='curl_params-sort_by contenteditable' contenteditable='true'>created_on:desc</span>" \
+    --data-urlencode "limit=20" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
 </div>

--- a/source/documentation/rest/incidents/notes/create.html
+++ b/source/documentation/rest/incidents/notes/create.html
@@ -2,11 +2,174 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents/notes">Notes</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents/notes">Notes</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST incidents/:incident_id/notes</h1><p>Create a new note for the specified incident.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/notes</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>note</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Yes</td><td>The note object that includes the new note parameters.
-</td></tr><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div><h3>Note Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>content</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The note content
-</td></tr></tbody></table></div><h3>Example</h3>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>","note":{"content":"<span class='curl_params-content contenteditable' contenteditable='true'>New Note</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">PQL04E1</span>/notes"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;note&quot;: {&#x000A;    &quot;id&quot;: 22013,&#x000A;    &quot;user&quot;: {&#x000A;      &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;      &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;      &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;purple&quot;,&#x000A;      &quot;role&quot;: &quot;owner&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;      &quot;invitation_sent&quot;: false,&#x000A;      &quot;marketing_opt_out&quot;: false&#x000A;    },&#x000A;    &quot;content&quot;: &quot;New Note&quot;,&#x000A;    &quot;created_at&quot;: &quot;2013-04-08T14:54:33-04:00&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST incidents/:incident_id/notes
+  </h1>
+  <p>
+    Create a new note for the specified incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/notes
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            note
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The note object that includes the new note parameters.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Note Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            content
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The note content
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>","note":{"content":"<span class='curl_params-content contenteditable' contenteditable='true'>New Note</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">PQL04E1</span>/notes"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "note": {
+    "id": 22013,
+    "user": {
+      "id": "PT23IWX",
+      "name": "Tim Wright",
+      "email": "tim@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "purple",
+      "role": "owner",
+      "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+      "user_url": "/users/PT23IWX",
+      "invitation_sent": false,
+      "marketing_opt_out": false
+    },
+    "content": "New Note",
+    "created_at": "2013-04-08T14:54:33-04:00"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/incidents/notes/index.html
+++ b/source/documentation/rest/incidents/notes/index.html
@@ -2,9 +2,57 @@
 title: Notes API
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Notes</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Notes
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Incident Notes API</h1>
-<table class="table action_index"><caption>The Incident Notes API allows you to add notes to a specified incident.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/incidents/notes/list">GET incidents/:incident_id/notes</a></td><td>List existing notes for the specified incident.</td></tr><tr><td><a href="/documentation/rest/incidents/notes/create">POST incidents/:incident_id/notes</a></td><td>Create a new note for the specified incident.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Incident Notes API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      The Incident Notes API allows you to add notes to a specified incident.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/notes/list">GET incidents/:incident_id/notes</a>
+        </td>
+        <td>
+          List existing notes for the specified incident.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/incidents/notes/create">POST incidents/:incident_id/notes</a>
+        </td>
+        <td>
+          Create a new note for the specified incident.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/incidents/notes/list.html
+++ b/source/documentation/rest/incidents/notes/list.html
@@ -2,8 +2,83 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents/notes">Notes</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents/notes">Notes</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET incidents/:incident_id/notes</h1><p>List existing notes for the specified incident.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/notes</pre></div><h3>Example</h3>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">PQL04E1</span>/notes"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;notes&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: 22012,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;content&quot;: &quot;I caught up to it and told it to slow down.&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-04-08T14:53:33-04:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET incidents/:incident_id/notes
+  </h1>
+  <p>
+    List existing notes for the specified incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/notes
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">PQL04E1</span>/notes"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "notes": [
+    {
+      "id": 22012,
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "content": "I caught up to it and told it to slow down.",
+      "created_at": "2013-04-08T14:53:33-04:00"
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/incidents/reassign.html
+++ b/source/documentation/rest/incidents/reassign.html
@@ -2,17 +2,122 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Reassign</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Reassign
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT incidents/:id/reassign</h1><p>Reassign an incident.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/reassign</pre></div><p>
-The status of this request will be 200 if the updates succeed.
-</p>
-<p>
-One and only one of the following parameters must be specified.
-</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This will be added to the incident log entry.
-This is only needed if you are using token based authentication.
-</td></tr><tr><td>escalation_policy</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The ID of an escalation policy. Delegate the incident to this escalation policy.
-</td></tr><tr><td>escalation_level</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>Escalate incident to this level in the escalation policy.
-</td></tr><tr><td>assigned_to_user</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Comma separated list of user IDs to assign this incident to.
-</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    PUT incidents/:id/reassign
+  </h1>
+  <p>
+    Reassign an incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/reassign
+</pre>
+  </div>
+  <p>
+    The status of this request will be 200 if the updates succeed.
+  </p>
+  <p>
+    One and only one of the following parameters must be specified.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This will be added to the incident log entry. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The ID of an escalation policy. Delegate the incident to this escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_level
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Escalate incident to this level in the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Comma separated list of user IDs to assign this incident to.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/incidents/resolve.html
+++ b/source/documentation/rest/incidents/resolve.html
@@ -2,11 +2,77 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Resolve</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Resolve
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT incidents/:id/resolve</h1><p>Resolve an incident.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/resolve</pre></div><p>
-The status of this request will be 200 if the update succeeded.
-</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This will be added to the incident log entry.
-This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    PUT incidents/:id/resolve
+  </h1>
+  <p>
+    Resolve an incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>/resolve
+</pre>
+  </div>
+  <p>
+    The status of this request will be 200 if the update succeeded.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This will be added to the incident log entry. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/incidents/show.html
+++ b/source/documentation/rest/incidents/show.html
@@ -2,12 +2,141 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET incidents/:id</h1><p>Show detailed information about an incident. Accepts either an incident id, or an incident number.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example: using incident id</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;  &quot;incident_number&quot;: 1,&#x000A;  &quot;created_on&quot;: &quot;2012-12-22T00:35:21Z&quot;,&#x000A;  &quot;status&quot;: &quot;triggered&quot;,&#x000A;  &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7&quot;,&#x000A;  &quot;incident_key&quot;: null,&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;    &quot;name&quot;: &quot;service&quot;,&#x000A;    &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PBAZLIU&quot;&#x000A;  },&#x000A;  &quot;assigned_to_user&quot;: {&#x000A;    &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;    &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;    &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;    &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;&#x000A;  },&#x000A;  &quot;assigned_to&quot;: [&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2012-12-22T00:35:21Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;        &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;        &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;trigger_summary_data&quot;: {&#x000A;    &quot;subject&quot;: &quot;45645&quot;&#x000A;  },&#x000A;  &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7&quot;,&#x000A;  &quot;last_status_change_on&quot;: &quot;2012-12-22T00:35:22Z&quot;,&#x000A;  &quot;last_status_change_by&quot;: null&#x000A;}</code></pre></div>
-<h3>Example: using incident number</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">1</span>"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;  &quot;incident_number&quot;: 1,&#x000A;  &quot;created_on&quot;: &quot;2012-12-22T00:35:21Z&quot;,&#x000A;  &quot;status&quot;: &quot;triggered&quot;,&#x000A;  &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7&quot;,&#x000A;  &quot;incident_key&quot;: null,&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;    &quot;name&quot;: &quot;service&quot;,&#x000A;    &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PBAZLIU&quot;&#x000A;  },&#x000A;  &quot;assigned_to_user&quot;: {&#x000A;    &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;    &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;    &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;    &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;&#x000A;  },&#x000A;  &quot;assigned_to&quot;: [&#x000A;    {&#x000A;      &quot;at&quot;: &quot;2012-12-22T00:35:21Z&quot;,&#x000A;      &quot;object&quot;: {&#x000A;        &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;        &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;        &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;        &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;trigger_summary_data&quot;: {&#x000A;    &quot;subject&quot;: &quot;45645&quot;&#x000A;  },&#x000A;  &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7&quot;,&#x000A;  &quot;last_status_change_on&quot;: &quot;2012-12-22T00:35:22Z&quot;,&#x000A;  &quot;last_status_change_by&quot;: null&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET incidents/:id
+  </h1>
+  <p>
+    Show detailed information about an incident. Accepts either an incident id, or an incident number.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example: using incident id
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "id": "PIJ90N7",
+  "incident_number": 1,
+  "created_on": "2012-12-22T00:35:21Z",
+  "status": "triggered",
+  "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
+  "incident_key": null,
+  "service": {
+    "id": "PBAZLIU",
+    "name": "service",
+    "html_url": "https://acme.pagerduty.com/services/PBAZLIU"
+  },
+  "assigned_to_user": {
+    "id": "PPI9KUT",
+    "name": "Alan Kay",
+    "email": "alan@pagerduty.com",
+    "html_url": "https://acme.pagerduty.com/users/PPI9KUT"
+  },
+  "assigned_to": [
+    {
+      "at": "2012-12-22T00:35:21Z",
+      "object": {
+        "id": "PPI9KUT",
+        "name": "Alan Kay",
+        "email": "alan@pagerduty.com",
+        "html_url": "https://acme.pagerduty.com/users/PPI9KUT",
+        "type": "user"
+      }
+    }
+  ],
+  "trigger_summary_data": {
+    "subject": "45645"
+  },
+  "trigger_details_html_url": "https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7",
+  "last_status_change_on": "2012-12-22T00:35:22Z",
+  "last_status_change_by": null
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example: using incident number
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">1</span>"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "id": "PIJ90N7",
+  "incident_number": 1,
+  "created_on": "2012-12-22T00:35:21Z",
+  "status": "triggered",
+  "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
+  "incident_key": null,
+  "service": {
+    "id": "PBAZLIU",
+    "name": "service",
+    "html_url": "https://acme.pagerduty.com/services/PBAZLIU"
+  },
+  "assigned_to_user": {
+    "id": "PPI9KUT",
+    "name": "Alan Kay",
+    "email": "alan@pagerduty.com",
+    "html_url": "https://acme.pagerduty.com/users/PPI9KUT"
+  },
+  "assigned_to": [
+    {
+      "at": "2012-12-22T00:35:21Z",
+      "object": {
+        "id": "PPI9KUT",
+        "name": "Alan Kay",
+        "email": "alan@pagerduty.com",
+        "html_url": "https://acme.pagerduty.com/users/PPI9KUT",
+        "type": "user"
+      }
+    }
+  ],
+  "trigger_summary_data": {
+    "subject": "45645"
+  },
+  "trigger_details_html_url": "https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7",
+  "last_status_change_on": "2012-12-22T00:35:22Z",
+  "last_status_change_by": null
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/incidents/update.html
+++ b/source/documentation/rest/incidents/update.html
@@ -2,19 +2,273 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/incidents">Incidents</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/incidents">Incidents</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT incidents</h1><p>Acknowledge, resolve, escalate or reassign one or more incidents.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents</pre></div><p>
-The status of this request will be 200 if and only if all of the updates succeed. Nonetheless, this request is <b>not</b> atomic: if it gives a 400 error, the error code must be checked out to see which incidents failed to be updated.
-</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>incidents</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>An array of incidents, including the parameters to update.
-</td></tr><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This will be added to the incident log entry.
-This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div><h3>Incident Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the incident to update.
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The new status of the incident. Possible values are <code>resolved</code> and <code>acknowledged</code>.
-</td></tr><tr><td>escalation_level</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>Escalate incident to this level in the escalation policy.
-</td></tr><tr><td>assigned_to_user</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Comma separated list of user IDs to assign this incident to.
-</td></tr><tr><td>escalation_policy</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Delegate this incident to the specified escalation policy id. This restarts the incident's escalation following the new policy.
-</td></tr></tbody></table></div><h2>Examples</h2>
-<h3>Example 1</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>","incidents":[{"id":"<span class='curl_params-id contenteditable' contenteditable='true'>P31FZLG</span>","status":"<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"}]}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;incidents&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P31FZLG&quot;,&#x000A;      &quot;status&quot;: &quot;resolved&quot;,&#x000A;      &quot;incident_number&quot;: 2,&#x000A;      &quot;url&quot;: &quot;https://acme.pageduty.com/incidents/P31FZLG&quot;,&#x000A;      &quot;error&quot;: {&#x000A;        &quot;message&quot;: &quot;Incident Already Resolved&quot;,&#x000A;        &quot;code&quot;: 1001&#x000A;      }&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div><h3>Example 2: Invalid ID</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{    &#x000A;      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>",&#x000A;      "incidents": [&#x000A;        {&#x000A;          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P31FZLG</span>",&#x000A;          "status": "<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"&#x000A;        },&#x000A;        {&#x000A;          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>badid</span>",&#x000A;          "status": "<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"&#x000A;        }&#x000A;      ]&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code></pre><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;incidents&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P31FZLG&quot;,&#x000A;      &quot;status&quot;: &quot;resolved&quot;,&#x000A;      &quot;incident_number&quot;: 2,&#x000A;      &quot;url&quot;: &quot;https://acme.pageduty.com/incidents/P31FZLG&quot;,&#x000A;      &quot;error&quot;: {&#x000A;        &quot;message&quot;: &quot;Incident Already Resolved&quot;,&#x000A;        &quot;code&quot;: 1001&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;badid&quot;,&#x000A;      &quot;status&quot;: &quot;resolved&quot;,&#x000A;      &quot;incident_number&quot;: null,&#x000A;      &quot;url&quot;: null,&#x000A;      &quot;error&quot;: {&#x000A;        &quot;message&quot;: &quot;Invalid Id Provided&quot;,&#x000A;        &quot;code&quot;: 1004&#x000A;      }&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT incidents
+  </h1>
+  <p>
+    Acknowledge, resolve, escalate or reassign one or more incidents.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents
+</pre>
+  </div>
+  <p>
+    The status of this request will be 200 if and only if all of the updates succeed. Nonetheless, this request is <b>not</b> atomic: if it gives a 400 error, the error code must be checked out to see which incidents failed to be updated.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            incidents
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            An array of incidents, including the parameters to update.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This will be added to the incident log entry. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Incident Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the incident to update.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The new status of the incident. Possible values are <code>resolved</code> and <code>acknowledged</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_level
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Escalate incident to this level in the escalation policy.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_to_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Comma separated list of user IDs to assign this incident to.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Delegate this incident to the specified escalation policy id. This restarts the incident's escalation following the new policy.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h3>
+    Example 1
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>","incidents":[{"id":"<span class='curl_params-id contenteditable' contenteditable='true'>P31FZLG</span>","status":"<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"}]}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "incidents": [
+    {
+      "id": "P31FZLG",
+      "status": "resolved",
+      "incident_number": 2,
+      "url": "https://acme.pageduty.com/incidents/P31FZLG",
+      "error": {
+        "message": "Incident Already Resolved",
+        "code": 1001
+      }
+    }
+  ]
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example 2: Invalid ID
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{    
+      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PPSFHH7</span>",
+      "incidents": [
+        {
+          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P31FZLG</span>",
+          "status": "<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"
+        },
+        {
+          "id": "<span class='curl_params-id contenteditable' contenteditable='true'>badid</span>",
+          "status": "<span class='curl_params-status contenteditable' contenteditable='true'>resolved</span>"
+        }
+      ]
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "incidents": [
+    {
+      "id": "P31FZLG",
+      "status": "resolved",
+      "incident_number": 2,
+      "url": "https://acme.pageduty.com/incidents/P31FZLG",
+      "error": {
+        "message": "Incident Already Resolved",
+        "code": 1001
+      }
+    },
+    {
+      "id": "badid",
+      "status": "resolved",
+      "incident_number": null,
+      "url": null,
+      "error": {
+        "message": "Invalid Id Provided",
+        "code": 1004
+      }
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/index.html
+++ b/source/documentation/rest/index.html
@@ -5,40 +5,75 @@ permalink: /documentation/rest/
 redirect_from:
   - /documentation/rest/rest.html
 ---
-                  <ul class="breadcrumb">
-                    <li>REST API</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">REST API Documentation</h1>
-                    <p>This document describes the PagerDuty REST API, which allows users to achieve most tasks that can be done from the web UI programmatically. The API accepts JSON and form encoded content as input. The output is always in JSON (or empty, in the case of DELETE requests).</p>
-                    <p>Check out the pages below for general information about all of our REST APIs. To get right to it and dig into specific APIs, use the navigation on the left side of this site.</p>
-                    <h3>General Information</h3>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Page</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td><a href="/documentation/rest/authentication/">Authentication</a></td>
-                            <td>How to access the PagerDuty API.</td>
-                          </tr>
-                          <tr>
-                            <td><a href="/documentation/rest/errors/">Errors</a></td>
-                            <td>How errors are handled.</td>
-                          </tr>
-                          <tr>
-                            <td><a href="/documentation/rest/types/">Types</a></td>
-                            <td>How to format various data types.</td>
-                          </tr>
-                          <tr>
-                            <td><a href="/documentation/rest/pagination/">Pagination</a></td>
-                            <td>How data sets are paginated.</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>API Rate Limiting</h3>
-                    <p>Each account is limited to the number of API requests it can make every minute. API requests that exceed the API rate limit will return an HTTP status code of <code>403</code>.</p>
-                  </div>
+<ul class="breadcrumb">
+  <li>REST API
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    REST API Documentation
+  </h1>
+  <p>
+    This document describes the PagerDuty REST API, which allows users to achieve most tasks that can be done from the web UI programmatically. The API accepts JSON and form encoded content as input. The output is always in JSON (or empty, in the case of DELETE requests).
+  </p>
+  <p>
+    Check out the pages below for general information about all of our REST APIs. To get right to it and dig into specific APIs, use the navigation on the left side of this site.
+  </p>
+  <h3>
+    General Information
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Page
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <a href="/documentation/rest/authentication/">Authentication</a>
+          </td>
+          <td>
+            How to access the PagerDuty API.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a href="/documentation/rest/errors/">Errors</a>
+          </td>
+          <td>
+            How errors are handled.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a href="/documentation/rest/types/">Types</a>
+          </td>
+          <td>
+            How to format various data types.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a href="/documentation/rest/pagination/">Pagination</a>
+          </td>
+          <td>
+            How data sets are paginated.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    API Rate Limiting
+  </h3>
+  <p>
+    Each account is limited to the number of API requests it can make every minute. API requests that exceed the API rate limit will return an HTTP status code of <code>403</code>.
+  </p>
+</div>

--- a/source/documentation/rest/log_entries/incident_log_entries.html
+++ b/source/documentation/rest/log_entries/incident_log_entries.html
@@ -2,103 +2,483 @@
 title: PagerDuty Developer
 layout: main
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/rest">REST API</a></li>
-                    <span class="divider">/</span>
-                    <li><a href="/documentation/rest/log_entries">Log Entries</a></li>
-                    <span class="divider">/</span><li>Incident Log Entries</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">GET incidents/:incident_id/log_entries</h1>
-                    <p>List all incident log entries for a specific incident.</p>
-                    <h3>Resource URL</h3>
-                    <div class="prism action-url language-bash">
-                      <pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/log_entries</pre>
-                    </div>
-                    <h3>Parameters</h3>
-                    <div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Name</th>
-                          <th>Type</th>
-                          <th>Required</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>time_zone</td>
-                            <td><a href="/documentation/rest/types#timezone">Time Zone</a></td>
-                            <td>No</td>
-                            <td>Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code></td>
-                          </tr>
-                          <tr>
-                            <td>since</td>
-                            <td><a href="/documentation/rest/types#datetime">Date</a></td>
-                            <td>No</td>
-                            <td>The start of the date range over which you want to search.</td>
-                          </tr>
-                          <tr>
-                            <td>until</td>
-                            <td><a href="/documentation/rest/types#datetime">Date</a></td>
-                            <td>No</td>
-                            <td>The end of the date range over which you want to search.</td>
-                          </tr>
-                          <tr>
-                            <td>is_overview</td>
-                            <td><a href="/documentation/rest/types#boolean">Boolean</a></td>
-                            <td>No</td>
-                            <td>If <code>true</code>, will only return log entries of type <code>trigger</code>,<code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.</td>
-                          </tr>
-                          <tr>
-                            <td>include</td>
-                            <td><a href="/documentation/rest/types#array">Array</a></td>
-                            <td>No</td>
-                            <td>Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>, and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>Response Fields</h3>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Name</th>
-                          <th>Type</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>log_entries</td>
-                            <td><a href="/documentation/rest/types#array">Array</a></td>
-                            <td>Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.</td>
-                          </tr>
-                          <tr>
-                            <td>total</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Total number of log entries matching the request ignoring pagination.</td>
-                          </tr>
-                          <tr>
-                            <td>offset</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Echoes offset pagination parameter.</td>
-                          </tr>
-                          <tr>
-                            <td>limit</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Echoes limit pagination parameter.</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>Example</h3>
-                    <h3>Example</h3>
-                    <pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">P31FZLG</span>/log_entries"</code></pre>
-                    <p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p>
-                    <div class="clearfix">
-                    </div>
-                    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-                    <div class="response">
-                      <pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;log_entries&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PPV5KG7&quot;,&#x000A;      &quot;type&quot;: &quot;resolve&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:33:15Z&quot;,&#x000A;      &quot;note&quot;: &quot;Fixed&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PVALU1K&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:08:43Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P8MDTZ8&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:00:30Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHCXXHR&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:00:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PE5XGDA&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:31Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;sms&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P9DWJ9J&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:30Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P36T0K8&quot;,&#x000A;      &quot;type&quot;: &quot;unacknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKU5VMR&quot;,&#x000A;      &quot;type&quot;: &quot;acknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:29:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;phone&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P36HB17&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:51Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PBJBF9Q&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:50Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;phone&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PRD9J7P&quot;,&#x000A;      &quot;type&quot;: &quot;assign&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;auto&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PVPXJJC&quot;,&#x000A;      &quot;type&quot;: &quot;trigger&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;summary&quot;: &quot;Martian&#x27;s are attacking&quot;,&#x000A;        &quot;type&quot;: &quot;web_trigger&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 12&#x000A;}</code></pre>
-                    </div>
-                  </div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/log_entries">Log Entries</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Incident Log Entries
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    GET incidents/:incident_id/log_entries
+  </h1>
+  <p>
+    List all incident log entries for a specific incident.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/incidents/<span class="url_param contenteditable" contenteditable="true">:incident_id</span>/log_entries
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            is_overview
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            If <code>true</code>, will only return log entries of type <code>trigger</code>,<code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>, and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            log_entries
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            total
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Total number of log entries matching the request ignoring pagination.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            offset
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes offset pagination parameter.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            limit
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes limit pagination parameter.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/incidents/<span class="sub_params_in_url-incident_id incident_id contenteditable" contenteditable="true">P31FZLG</span>/log_entries"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "log_entries": [
+    {
+      "id": "PPV5KG7",
+      "type": "resolve",
+      "created_at": "2013-03-06T21:33:15Z",
+      "note": "Fixed",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PVALU1K",
+      "type": "notify",
+      "created_at": "2013-03-06T21:08:43Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "P8MDTZ8",
+      "type": "notify",
+      "created_at": "2013-03-06T21:00:30Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PHCXXHR",
+      "type": "escalate",
+      "created_at": "2013-03-06T21:00:30Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PE5XGDA",
+      "type": "notify",
+      "created_at": "2013-03-06T20:59:31Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "sms",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "P9DWJ9J",
+      "type": "notify",
+      "created_at": "2013-03-06T20:59:30Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "P36T0K8",
+      "type": "unacknowledge",
+      "created_at": "2013-03-06T20:59:30Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      }
+    },
+    {
+      "id": "PKU5VMR",
+      "type": "acknowledge",
+      "created_at": "2013-03-06T20:29:30Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "phone"
+      }
+    },
+    {
+      "id": "P36HB17",
+      "type": "notify",
+      "created_at": "2013-03-06T20:28:51Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PBJBF9Q",
+      "type": "notify",
+      "created_at": "2013-03-06T20:28:50Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "phone",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PRD9J7P",
+      "type": "assign",
+      "created_at": "2013-03-06T20:28:46Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "auto"
+      },
+      "assigned_user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PVPXJJC",
+      "type": "trigger",
+      "created_at": "2013-03-06T20:28:46Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "summary": "Martian's are attacking",
+        "type": "web_trigger"
+      }
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 12
+}</code>
+</pre>
+  </div>
+</div>

--- a/source/documentation/rest/log_entries/index.html
+++ b/source/documentation/rest/log_entries/index.html
@@ -2,35 +2,67 @@
 title: PagerDuty Developer
 layout: main
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/rest">REST API</a></li>
-                    <span class="divider">/</span><li>Log Entries</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">Log Entries API</h1>
-                    <table class="table action_index">
-                      <caption>PagerDuty keeps a log of all the events that happen to an incident. The following APIs provide fine-grained access to this incident log entry data to give you more insight into how your team or organization is handling your incidents. Log entry data includes details about the event(s) that triggered the incident, who was notified and when, how they were notified, and who acknowledged or resolved it, amongst a few other things.</caption>
-                      <thead>
-                        <th>Resource</th>
-                        <th>Description</th>
-                      </thead>
-                      <tbody>
-                        <tr>
-                          <td><a href="/documentation/rest/log_entries/list">GET log_entries</a></td>
-                          <td>List all incident log entries across the entire account.</td>
-                        </tr>
-                        <tr>
-                          <td><a href="/documentation/rest/log_entries/user_log_entries">GET users/:user_id/log_entries</a></td>
-                          <td>List all incident log entries that describe interactions with a specific user.</td>
-                        </tr>
-                        <tr>
-                          <td><a href="/documentation/rest/log_entries/incident_log_entries">GET incidents/:incident_id/log_entries</a></td>
-                          <td>List all incident log entries for a specific incident.</td>
-                        </tr>
-                        <tr>
-                          <td><a href="/documentation/rest/log_entries/show">GET log_entries/:id</a></td>
-                          <td>Get details for a specific incident log entry. This method provides additional information you can use to get at raw event data.</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  </div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Log Entries
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    Log Entries API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      PagerDuty keeps a log of all the events that happen to an incident. The following APIs provide fine-grained access to this incident log entry data to give you more insight into how your team or organization is handling your incidents. Log entry data includes details about the event(s) that triggered the incident, who was notified and when, how they were notified, and who acknowledged or resolved it, amongst a few other things.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/log_entries/list">GET log_entries</a>
+        </td>
+        <td>
+          List all incident log entries across the entire account.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/log_entries/user_log_entries">GET users/:user_id/log_entries</a>
+        </td>
+        <td>
+          List all incident log entries that describe interactions with a specific user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/log_entries/incident_log_entries">GET incidents/:incident_id/log_entries</a>
+        </td>
+        <td>
+          List all incident log entries for a specific incident.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/log_entries/show">GET log_entries/:id</a>
+        </td>
+        <td>
+          Get details for a specific incident log entry. This method provides additional information you can use to get at raw event data.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/log_entries/list.html
+++ b/source/documentation/rest/log_entries/list.html
@@ -2,99 +2,862 @@
 title: PagerDuty Developer
 layout: main
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/rest">REST API</a></li>
-                    <span class="divider">/</span>
-                    <li><a href="/documentation/rest/log_entries">Log Entries</a></li>
-                    <span class="divider">/</span>
-                    <li>List</li>
-                  </ul>
-                  <div class='section'>
-                    <h1 class="title">GET log_entries</h1>
-                    <p>List all incident log entries across the entire account.</p>
-                    <h3>Resource URL</h3>
-                    <div class="prism action-url language-bash">
-                      <pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/log_entries</pre>
-                    </div>
-                    <h3>Parameters</h3>
-                    <div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Name</th>
-                          <th>Type</th>
-                          <th>Required</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>time_zone</td>
-                            <td><a href="/documentation/rest/types#timezone">Time Zone</a></td>
-                            <td>No</td>
-                            <td>Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code></td>
-                          </tr>
-                          <tr>
-                            <td>since</td>
-                            <td><a href="/documentation/rest/types#datetime">Date</a></td>
-                            <td>No</td>
-                            <td>The start of the date range over which you want to search.</td>
-                          </tr>
-                          <tr>
-                            <td>until</td>
-                            <td><a href="/documentation/rest/types#datetime">Date</a></td>
-                            <td>No</td>
-                            <td>The end of the date range over which you want to search.</td>
-                          </tr>
-                          <tr>
-                            <td>is_overview</td>
-                            <td><a href="/documentation/rest/types#boolean">Boolean</a></td>
-                            <td>No</td>
-                            <td>If <code>true</code>, will only return log entries of type <code>trigger</code>, <code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.</td>
-                          </tr>
-                          <tr>
-                            <td>include</td>
-                            <td><a href="/documentation/rest/types#array">Array</a></td>
-                            <td>No</td>
-                            <td>Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>, and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>Response Fields</h3>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Name</th>
-                          <th>Type</th>
-                          <th>Description</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>log_entries</td>
-                            <td><a href="/documentation/rest/types#array">Array</a></td>
-                            <td>Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.</td>
-                          </tr>
-                          <tr>
-                            <td>total</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Total number of log entries matching the request ignoring pagination.</td>
-                          </tr>
-                          <tr>
-                            <td>offset</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Echoes offset pagination parameter.</td>
-                          </tr>
-                          <tr>
-                            <td>limit</td>
-                            <td><a href="/documentation/rest/types#int">Integer</a></td>
-                            <td>Echoes limit pagination parameter.</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <h3>Example</h3>
-                    <pre>
-                    <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;log_entries&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PPV5KG7&quot;,&#x000A;      &quot;type&quot;: &quot;resolve&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:33:15Z&quot;,&#x000A;      &quot;note&quot;: &quot;Fixed&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PEAJ6BC&quot;,&#x000A;      &quot;type&quot;: &quot;resolve&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:33:02Z&quot;,&#x000A;      &quot;note&quot;: &quot;Fixed&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PS1ATPX&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:08:43Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PVALU1K&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:08:43Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PZN9UEN&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:08:43Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PZMKNZ5&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:07:43Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PDZ8OOV&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:07:43Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;sms&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKHHPD8&quot;,&#x000A;      &quot;type&quot;: &quot;unacknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:07:43Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P8MDTZ8&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:00:30Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHCXXHR&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:00:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PE5XGDA&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:31Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;sms&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P9DWJ9J&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:30Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P36T0K8&quot;,&#x000A;      &quot;type&quot;: &quot;unacknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:59:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHW1S5W&quot;,&#x000A;      &quot;type&quot;: &quot;acknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:37:43Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;sms&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P9DAN7O&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:36:46Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PQPLNJB&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:36:46Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;sms&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PXYXPOR&quot;,&#x000A;      &quot;type&quot;: &quot;assign&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:36:45Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;auto&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PB7IQ0E&quot;,&#x000A;      &quot;type&quot;: &quot;trigger&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:36:45Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;summary&quot;: &quot;Server full of cats&quot;,&#x000A;        &quot;type&quot;: &quot;web_trigger&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKU5VMR&quot;,&#x000A;      &quot;type&quot;: &quot;acknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:29:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;phone&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P36HB17&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:51Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@pagerduty.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PBJBF9Q&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:50Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;phone&quot;,&#x000A;        &quot;address&quot;: &quot;+1 956-821-0372&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PRD9J7P&quot;,&#x000A;      &quot;type&quot;: &quot;assign&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;auto&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PVPXJJC&quot;,&#x000A;      &quot;type&quot;: &quot;trigger&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;summary&quot;: &quot;Martian&#x27;s are attacking&quot;,&#x000A;        &quot;type&quot;: &quot;web_trigger&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PABDPAI&quot;,&#x000A;      &quot;type&quot;: &quot;resolve&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:21:15Z&quot;,&#x000A;      &quot;note&quot;: &quot;Doused it with a water hose.&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKLZ54O&quot;,&#x000A;      &quot;type&quot;: &quot;acknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:18:13Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PE03WDN&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:16:32Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHZRXSA&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:16:32Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P6BSRS1&quot;,&#x000A;      &quot;type&quot;: &quot;notify&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:15:33Z&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;notification&quot;: {&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;address&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;status&quot;: &quot;success&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PQK1SGE&quot;,&#x000A;      &quot;type&quot;: &quot;assign&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:15:32Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;auto&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;        &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;        &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;purple&quot;,&#x000A;        &quot;role&quot;: &quot;owner&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;        &quot;invitation_sent&quot;: false,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PUWPTW4&quot;,&#x000A;      &quot;type&quot;: &quot;trigger&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:15:32Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;summary&quot;: &quot;Your server&#x27;s on fire!&quot;,&#x000A;        &quot;type&quot;: &quot;email&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 30&#x000A;}</code>
-                    </pre>
-                  </div>
-                </div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/log_entries">Log Entries</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    GET log_entries
+  </h1>
+  <p>
+    List all incident log entries across the entire account.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/log_entries
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            is_overview
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            If <code>true</code>, will only return log entries of type <code>trigger</code>, <code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>, and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            log_entries
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            total
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Total number of log entries matching the request ignoring pagination.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            offset
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes offset pagination parameter.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            limit
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes limit pagination parameter.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+                    <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "log_entries": [
+    {
+      "id": "PPV5KG7",
+      "type": "resolve",
+      "created_at": "2013-03-06T21:33:15Z",
+      "note": "Fixed",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PEAJ6BC",
+      "type": "resolve",
+      "created_at": "2013-03-06T21:33:02Z",
+      "note": "Fixed",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PS1ATPX",
+      "type": "notify",
+      "created_at": "2013-03-06T21:08:43Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PVALU1K",
+      "type": "notify",
+      "created_at": "2013-03-06T21:08:43Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PZN9UEN",
+      "type": "escalate",
+      "created_at": "2013-03-06T21:08:43Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PZMKNZ5",
+      "type": "notify",
+      "created_at": "2013-03-06T21:07:43Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PDZ8OOV",
+      "type": "notify",
+      "created_at": "2013-03-06T21:07:43Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "sms",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PKHHPD8",
+      "type": "unacknowledge",
+      "created_at": "2013-03-06T21:07:43Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      }
+    },
+    {
+      "id": "P8MDTZ8",
+      "type": "notify",
+      "created_at": "2013-03-06T21:00:30Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PHCXXHR",
+      "type": "escalate",
+      "created_at": "2013-03-06T21:00:30Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PE5XGDA",
+      "type": "notify",
+      "created_at": "2013-03-06T20:59:31Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "sms",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "P9DWJ9J",
+      "type": "notify",
+      "created_at": "2013-03-06T20:59:30Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "P36T0K8",
+      "type": "unacknowledge",
+      "created_at": "2013-03-06T20:59:30Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      }
+    },
+    {
+      "id": "PHW1S5W",
+      "type": "acknowledge",
+      "created_at": "2013-03-06T20:37:43Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "sms"
+      }
+    },
+    {
+      "id": "P9DAN7O",
+      "type": "notify",
+      "created_at": "2013-03-06T20:36:46Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PQPLNJB",
+      "type": "notify",
+      "created_at": "2013-03-06T20:36:46Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "sms",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PXYXPOR",
+      "type": "assign",
+      "created_at": "2013-03-06T20:36:45Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "auto"
+      },
+      "assigned_user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PB7IQ0E",
+      "type": "trigger",
+      "created_at": "2013-03-06T20:36:45Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "summary": "Server full of cats",
+        "type": "web_trigger"
+      }
+    },
+    {
+      "id": "PKU5VMR",
+      "type": "acknowledge",
+      "created_at": "2013-03-06T20:29:30Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "phone"
+      }
+    },
+    {
+      "id": "P36HB17",
+      "type": "notify",
+      "created_at": "2013-03-06T20:28:51Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@pagerduty.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PBJBF9Q",
+      "type": "notify",
+      "created_at": "2013-03-06T20:28:50Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "phone",
+        "address": "+1 956-821-0372",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PRD9J7P",
+      "type": "assign",
+      "created_at": "2013-03-06T20:28:46Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "auto"
+      },
+      "assigned_user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PVPXJJC",
+      "type": "trigger",
+      "created_at": "2013-03-06T20:28:46Z",
+      "agent": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "summary": "Martian's are attacking",
+        "type": "web_trigger"
+      }
+    },
+    {
+      "id": "PABDPAI",
+      "type": "resolve",
+      "created_at": "2013-01-31T03:21:15Z",
+      "note": "Doused it with a water hose.",
+      "agent": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PKLZ54O",
+      "type": "acknowledge",
+      "created_at": "2013-01-31T03:18:13Z",
+      "agent": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PE03WDN",
+      "type": "notify",
+      "created_at": "2013-01-31T03:16:32Z",
+      "user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "bob@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PHZRXSA",
+      "type": "escalate",
+      "created_at": "2013-01-31T03:16:32Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "P6BSRS1",
+      "type": "notify",
+      "created_at": "2013-01-31T03:15:33Z",
+      "user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "notification": {
+        "type": "email",
+        "address": "tim@acme.com",
+        "status": "success"
+      }
+    },
+    {
+      "id": "PQK1SGE",
+      "type": "assign",
+      "created_at": "2013-01-31T03:15:32Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "auto"
+      },
+      "assigned_user": {
+        "id": "PT23IWX",
+        "name": "Tim Wright",
+        "email": "tim@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "purple",
+        "role": "owner",
+        "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+        "user_url": "/users/PT23IWX",
+        "invitation_sent": false,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PUWPTW4",
+      "type": "trigger",
+      "created_at": "2013-01-31T03:15:32Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "summary": "Your server's on fire!",
+        "type": "email"
+      }
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 30
+}</code>
+                    
+</pre>
+  </div>
+</div>

--- a/source/documentation/rest/log_entries/show.html
+++ b/source/documentation/rest/log_entries/show.html
@@ -2,73 +2,938 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/log_entries">Log Entries</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/log_entries">Log Entries</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET log_entries/:id</h1><p>Get details for a specific incident log entry. This method provides additional information you can use to get at raw event data.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/log_entries/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
-</td></tr><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. Accepts <code>channel</code> (See "Channel Type" for details),
-<code>incident</code>, and <code>service</code>.
-</td></tr></tbody></table></div><h2>Log Entry Types</h2>
-<p>Log entries come in a wide variety of types, as listed in the following table. Most types use the same <a href="#standard_format">format</a>, the exception being the <code>notify</code> type, whose format is detailed <a href="#notify_format">below</a>.</p>
-<div class="table-container"><table class="table table-striped"><thead><th>Type</th><th>Description</th></thead><tbody><tr><td>trigger</td><td>The incident was triggered.</td></tr>
-<tr><td>acknowledge</td><td>The incident was acknowledged.</td></tr>
-<tr><td>unacknowledge</td><td>The incident was unacknowledged.</td></tr>
-<tr><td>resolve</td><td>The incident was resolved.</td></tr>
-<tr><td>escalate</td><td>The incident was escalated.</td></tr>
-<tr><td>assign</td><td>The incident was assigned to a user.</td></tr>
-<tr><td>annotate</td><td>A note was added to the incident.</td></tr>
-<tr><td>reach_trigger_limit</td><td>The incident has reached the log entry trigger limit and will not create any more.</td></tr>
-<tr><td>repeat_escalation_path</td><td>The incident has reached the end of its escalation policy and will restart.</td></tr>
-<tr><td>exhaust_escalation_path</td><td>The incident has cycled through its escalation policy the max allowed number of times.</td></tr>
-<tr><td>notify</td><td>A user was notified.</td></tr>
-</tbody></table></div><h3 id="standard_format">Standard Log Entry Response Format</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>ID of the log entry.
-</td></tr><tr><td>created_at</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Time at which the log entry was created.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>The type of the log entry. Will be one of the above types.
-</td></tr><tr><td>agent</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Polymorphic object representation of the perfomer of this action. Has different formats depending on type, indicated by <code>agent[type]</code>, which will be one of <code>service</code> or <code>user</code>. See <a href="#agent_types">below</a> for detailed information about agent formats.
-</td></tr><tr><td>channel</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Polymorphic object representation of the means by which the action was channeled. Has different formats depending on type, indicated by channel[type]. Will be one of <code>auto</code>, <code>email</code>, <code>api</code>, <code>nagios</code>, or <code>timeout</code> if <code>agent[type]</code> is <code>service</code>. Will be one of <code>email</code>, <code>sms</code>, <code>website</code>, <code>web_trigger</code>, or <code>note</code> if <code>agent[type]</code> is <code>user</code>. See <a href="#channel_types">below</a> for detailed information about channel formats.
-</td></tr><tr><td>note</td><td><a href="/documentation/rest/types#string">String</a></td><td>Optional field containing an action note, if one was included with the action.
-</td></tr><tr><td>assigned_user</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Only for <code>assign</code>, <code>escalate</code> log entries. The user to which the incident is assigned.
-</td></tr></tbody></table></div><h2 id='agent_types'>Agent Types</h2>
-<p>The <code>agent</code> field represents the entity that carried out the action represented by the ILE.</p>
-<div class="table-container"><table class="table table-striped"><thead><th>type</th><th>description</th></thead><tbody><tr><td>user</td><td>User that carried out the action. See the <a href="/documentation/rest/users/show">show user API</a> for format.</td></tr>
-<tr><td>service</td><td>Refers to the service to which the incident belongs. No fields besides <code>type</code>.</td></tr>
-</tbody></table></div><h2 id='channel_types'>Channel Types</h2>
-<p>The <code>channel</code> field represents the means by which the action was carried out. By default only the <code>type</code> and <code>summary</code> fields are included in the channel. To get detailed information for the channel, you must include <code>channel</code> in the <code>include</code> request parameter. All types not detailed here will only have the <code>type</code> field.</p>
-<div class="expandable"><div class="header toggle"><i class="icon-chevron-right"></i><h3>Nagios Channel Type</h3></div><div class="content"><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Will be <code>nagios</code>
-</td></tr><tr><td>summary</td><td><a href="/documentation/rest/types#string">String</a></td><td>Same as <code>host</code>
-</td></tr><tr><td>host</td><td><a href="/documentation/rest/types#string">String</a></td><td>Nagios host
-</td></tr><tr><td>service</td><td><a href="/documentation/rest/types#string">String</a></td><td>Nagios service that created the event, if applicable
-</td></tr><tr><td>state</td><td><a href="/documentation/rest/types#string">String</a></td><td>State the caused the event
-</td></tr><tr><td>details</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Additional details of the incident
-</td></tr></tbody></table></div></div></div><div class="expandable"><div class="header toggle"><i class="icon-chevron-right"></i><h3>API Channel Type</h3></div><div class="content"><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Will be <code>api</code>
-</td></tr><tr><td>summary</td><td><a href="/documentation/rest/types#string">String</a></td><td>Same as <code>description</code>
-</td></tr><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>API service key
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>Description of the event
-</td></tr><tr><td>incident_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Incident deduping string
-</td></tr><tr><td>details</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Additional details of the incident, if any
-</td></tr></tbody></table></div></div></div><div class="expandable"><div class="header toggle"><i class="icon-chevron-right"></i><h3>Email Channel Type</h3></div><div class="content"><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Will be <code>email</code>
-</td></tr><tr><td>summary</td><td><a href="/documentation/rest/types#string">String</a></td><td>Same as <code>subject</code>
-</td></tr><tr><td>to</td><td><a href="/documentation/rest/types#string">String</a></td><td>To address of the email
-</td></tr><tr><td>from</td><td><a href="/documentation/rest/types#string">String</a></td><td>From address of the email
-</td></tr><tr><td>subject</td><td><a href="/documentation/rest/types#string">String</a></td><td>Subject of the email
-</td></tr><tr><td>body</td><td><a href="/documentation/rest/types#string">String</a></td><td>Body of the email
-</td></tr><tr><td>body_content_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Content type of the email body. Will be <code>text/plain</code> or <code>text/html</code>
-</td></tr><tr><td>raw_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>URL for raw text of email
-</td></tr><tr><td>html_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>URL for html rendered version of the email. Only present if <code>content_type</code> is <code>text/html</code>
-</td></tr></tbody></table></div></div></div><div class="expandable"><div class="header toggle"><i class="icon-chevron-right"></i><h3>Web Trigger Channel Type</h3></div><div class="content"><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Will be <code>web_trigger</code>
-</td></tr><tr><td>summary</td><td><a href="/documentation/rest/types#string">String</a></td><td>Same as <code>subject</code>
-</td></tr><tr><td>subject</td><td><a href="/documentation/rest/types#string">String</a></td><td>Subject of the web trigger
-</td></tr><tr><td>details</td><td><a href="/documentation/rest/types#string">String</a></td><td>Details about the web trigger
-</td></tr></tbody></table></div></div></div><h2 id='notify_format'>Notify Log Entries</h2>
-<p>Notify log entries correspond to notifications sent to users. They have a distinct format from action log entries.</p>
-<div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>created_at</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Time at which the log entry was created
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Will be <code>notify</code>
-</td></tr><tr><td>user</td><td><a href="/documentation/rest/types#object">Object</a></td><td>User who was notified
-</td></tr><tr><td>notification</td><td><a href="/documentation/rest/types#object">Object</a></td><td>Object representing the notification itself
-</td></tr></tbody></table></div><h3>Notification Response Fields</h3>
-<div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Type of notification. Will be one of <code>phone</code>, <code>sms</code>, <code>ios_push_notification</code>, or <code>email</code>
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>The current status of the notification. Will be one of <code>success</code>, <code>blocked</code>, <code>busy</code>, <code>failed</code>, <code>no_answer</code>, or <code>bad_address</code>
-</td></tr><tr><td>address</td><td><a href="/documentation/rest/types#string">String</a></td><td>The address to which the notification was sent. I.e., an email address, phone number, or iPhone name
-</td></tr></tbody></table></div>
-<h2>Examples</h2>
-<h3>Plain Request</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PVPXJJC</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;log_entry&quot;: {&#x000A;    &quot;id&quot;: &quot;PVPXJJC&quot;,&#x000A;    &quot;type&quot;: &quot;trigger&quot;,&#x000A;    &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;    &quot;agent&quot;: {&#x000A;      &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;      &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;      &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;purple&quot;,&#x000A;      &quot;role&quot;: &quot;owner&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;      &quot;invitation_sent&quot;: false,&#x000A;      &quot;marketing_opt_out&quot;: false,&#x000A;      &quot;type&quot;: &quot;user&quot;&#x000A;    },&#x000A;    &quot;channel&quot;: {&#x000A;      &quot;summary&quot;: &quot;Martian&#x27;s are attacking&quot;,&#x000A;      &quot;type&quot;: &quot;web_trigger&quot;&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div><h3>Request Including Channel</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>channel</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PVPXJJC</span>"</code></pre><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;log_entry&quot;: {&#x000A;    &quot;id&quot;: &quot;PVPXJJC&quot;,&#x000A;    &quot;type&quot;: &quot;trigger&quot;,&#x000A;    &quot;created_at&quot;: &quot;2013-03-06T20:28:46Z&quot;,&#x000A;    &quot;agent&quot;: {&#x000A;      &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;      &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;      &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;purple&quot;,&#x000A;      &quot;role&quot;: &quot;owner&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PT23IWX&quot;,&#x000A;      &quot;invitation_sent&quot;: false,&#x000A;      &quot;marketing_opt_out&quot;: false,&#x000A;      &quot;type&quot;: &quot;user&quot;&#x000A;    },&#x000A;    &quot;channel&quot;: {&#x000A;      &quot;subject&quot;: &quot;Martian&#x27;s are attacking&quot;,&#x000A;      &quot;details&quot;: &quot;Wait, I&#x27;m a computer. How the hell do I know? &quot;,&#x000A;      &quot;summary&quot;: &quot;Martian&#x27;s are attacking&quot;,&#x000A;      &quot;type&quot;: &quot;web_trigger&quot;&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET log_entries/:id
+  </h1>
+  <p>
+    Get details for a specific incident log entry. This method provides additional information you can use to get at raw event data.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/log_entries/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. Accepts <code>channel</code> (See "Channel Type" for details), <code>incident</code>, and <code>service</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Log Entry Types
+  </h2>
+  <p>
+    Log entries come in a wide variety of types, as listed in the following table. Most types use the same <a href="#standard_format">format</a>, the exception being the <code>notify</code> type, whose format is detailed <a href="#notify_format">below</a>.
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            trigger
+          </td>
+          <td>
+            The incident was triggered.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            acknowledge
+          </td>
+          <td>
+            The incident was acknowledged.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            unacknowledge
+          </td>
+          <td>
+            The incident was unacknowledged.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            resolve
+          </td>
+          <td>
+            The incident was resolved.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalate
+          </td>
+          <td>
+            The incident was escalated.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assign
+          </td>
+          <td>
+            The incident was assigned to a user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            annotate
+          </td>
+          <td>
+            A note was added to the incident.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            reach_trigger_limit
+          </td>
+          <td>
+            The incident has reached the log entry trigger limit and will not create any more.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            repeat_escalation_path
+          </td>
+          <td>
+            The incident has reached the end of its escalation policy and will restart.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            exhaust_escalation_path
+          </td>
+          <td>
+            The incident has cycled through its escalation policy the max allowed number of times.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            notify
+          </td>
+          <td>
+            A user was notified.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3 id="standard_format">
+    Standard Log Entry Response Format
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            ID of the log entry.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            created_at
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Time at which the log entry was created.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The type of the log entry. Will be one of the above types.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            agent
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Polymorphic object representation of the perfomer of this action. Has different formats depending on type, indicated by <code>agent[type]</code>, which will be one of <code>service</code> or <code>user</code>. See <a href="#agent_types">below</a> for detailed information about agent formats.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            channel
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Polymorphic object representation of the means by which the action was channeled. Has different formats depending on type, indicated by channel[type]. Will be one of <code>auto</code>, <code>email</code>, <code>api</code>, <code>nagios</code>, or <code>timeout</code> if <code>agent[type]</code> is <code>service</code>. Will be one of <code>email</code>, <code>sms</code>, <code>website</code>, <code>web_trigger</code>, or <code>note</code> if <code>agent[type]</code> is <code>user</code>. See <a href="#channel_types">below</a> for detailed information about channel formats.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            note
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Optional field containing an action note, if one was included with the action.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            assigned_user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Only for <code>assign</code>, <code>escalate</code> log entries. The user to which the incident is assigned.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2 id='agent_types'>
+    Agent Types
+  </h2>
+  <p>
+    The <code>agent</code> field represents the entity that carried out the action represented by the ILE.
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            type
+          </th>
+          <th>
+            description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            user
+          </td>
+          <td>
+            User that carried out the action. See the <a href="/documentation/rest/users/show">show user API</a> for format.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service
+          </td>
+          <td>
+            Refers to the service to which the incident belongs. No fields besides <code>type</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2 id='channel_types'>
+    Channel Types
+  </h2>
+  <p>
+    The <code>channel</code> field represents the means by which the action was carried out. By default only the <code>type</code> and <code>summary</code> fields are included in the channel. To get detailed information for the channel, you must include <code>channel</code> in the <code>include</code> request parameter. All types not detailed here will only have the <code>type</code> field.
+  </p>
+  <div class="expandable">
+    <div class="header toggle">
+      <h3>
+        Nagios Channel Type
+      </h3>
+    </div>
+    <div class="content">
+      <div class="table-container">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>
+                Name
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                type
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Will be <code>nagios</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                summary
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Same as <code>host</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                host
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Nagios host
+              </td>
+            </tr>
+            <tr>
+              <td>
+                service
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Nagios service that created the event, if applicable
+              </td>
+            </tr>
+            <tr>
+              <td>
+                state
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                State the caused the event
+              </td>
+            </tr>
+            <tr>
+              <td>
+                details
+              </td>
+              <td>
+                <a href="/documentation/rest/types#object">Object</a>
+              </td>
+              <td>
+                Additional details of the incident
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="expandable">
+    <div class="header toggle">
+      <h3>
+        API Channel Type
+      </h3>
+    </div>
+    <div class="content">
+      <div class="table-container">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>
+                Name
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                type
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Will be <code>api</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                summary
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Same as <code>description</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                service_key
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                API service key
+              </td>
+            </tr>
+            <tr>
+              <td>
+                description
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Description of the event
+              </td>
+            </tr>
+            <tr>
+              <td>
+                incident_key
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Incident deduping string
+              </td>
+            </tr>
+            <tr>
+              <td>
+                details
+              </td>
+              <td>
+                <a href="/documentation/rest/types#object">Object</a>
+              </td>
+              <td>
+                Additional details of the incident, if any
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="expandable">
+    <div class="header toggle">
+      <h3>
+        Email Channel Type
+      </h3>
+    </div>
+    <div class="content">
+      <div class="table-container">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>
+                Name
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                type
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Will be <code>email</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                summary
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Same as <code>subject</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                to
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                To address of the email
+              </td>
+            </tr>
+            <tr>
+              <td>
+                from
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                From address of the email
+              </td>
+            </tr>
+            <tr>
+              <td>
+                subject
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Subject of the email
+              </td>
+            </tr>
+            <tr>
+              <td>
+                body
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Body of the email
+              </td>
+            </tr>
+            <tr>
+              <td>
+                body_content_type
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Content type of the email body. Will be <code>text/plain</code> or <code>text/html</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                raw_url
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                URL for raw text of email
+              </td>
+            </tr>
+            <tr>
+              <td>
+                html_url
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                URL for html rendered version of the email. Only present if <code>content_type</code> is <code>text/html</code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="expandable">
+    <div class="header toggle">
+      <h3>
+        Web Trigger Channel Type
+      </h3>
+    </div>
+    <div class="content">
+      <div class="table-container">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>
+                Name
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                type
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Will be <code>web_trigger</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                summary
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Same as <code>subject</code>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                subject
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Subject of the web trigger
+              </td>
+            </tr>
+            <tr>
+              <td>
+                details
+              </td>
+              <td>
+                <a href="/documentation/rest/types#string">String</a>
+              </td>
+              <td>
+                Details about the web trigger
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <h2 id='notify_format'>
+    Notify Log Entries
+  </h2>
+  <p>
+    Notify log entries correspond to notifications sent to users. They have a distinct format from action log entries.
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            created_at
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Time at which the log entry was created
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Will be <code>notify</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            user
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            User who was notified
+          </td>
+        </tr>
+        <tr>
+          <td>
+            notification
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            Object representing the notification itself
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Notification Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Type of notification. Will be one of <code>phone</code>, <code>sms</code>, <code>ios_push_notification</code>, or <code>email</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The current status of the notification. Will be one of <code>success</code>, <code>blocked</code>, <code>busy</code>, <code>failed</code>, <code>no_answer</code>, or <code>bad_address</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            address
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The address to which the notification was sent. I.e., an email address, phone number, or iPhone name
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h3>
+    Plain Request
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PVPXJJC</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "log_entry": {
+    "id": "PVPXJJC",
+    "type": "trigger",
+    "created_at": "2013-03-06T20:28:46Z",
+    "agent": {
+      "id": "PT23IWX",
+      "name": "Tim Wright",
+      "email": "tim@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "purple",
+      "role": "owner",
+      "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+      "user_url": "/users/PT23IWX",
+      "invitation_sent": false,
+      "marketing_opt_out": false,
+      "type": "user"
+    },
+    "channel": {
+      "summary": "Martian's are attacking",
+      "type": "web_trigger"
+    }
+  }
+}</code>
+</pre>
+  </div>
+  <h3>
+    Request Including Channel
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>channel</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/log_entries/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PVPXJJC</span>"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "log_entry": {
+    "id": "PVPXJJC",
+    "type": "trigger",
+    "created_at": "2013-03-06T20:28:46Z",
+    "agent": {
+      "id": "PT23IWX",
+      "name": "Tim Wright",
+      "email": "tim@acme.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "purple",
+      "role": "owner",
+      "avatar_url": "https://secure.gravatar.com/avatar/923a2b907dc04244e9bb5576a42e70a7.png?d=mm&amp;r=PG",
+      "user_url": "/users/PT23IWX",
+      "invitation_sent": false,
+      "marketing_opt_out": false,
+      "type": "user"
+    },
+    "channel": {
+      "subject": "Martian's are attacking",
+      "details": "Wait, I'm a computer. How the hell do I know? ",
+      "summary": "Martian's are attacking",
+      "type": "web_trigger"
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/log_entries/user_log_entries.html
+++ b/source/documentation/rest/log_entries/user_log_entries.html
@@ -2,20 +2,342 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/log_entries">Log Entries</a></li><span class="divider">/</span><li>User Log Entries</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/log_entries">Log Entries</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>User Log Entries
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:user_id/log_entries</h1><p>List all incident log entries that describe interactions with a specific user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/log_entries</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
-</td></tr><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The start of the date range over which you want to search.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end of the date range over which you want to search.
-</td></tr><tr><td>is_overview</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>If <code>true</code>, will only return log entries of type <code>trigger</code>,
-<code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.
-</td></tr><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>,
-and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)
-</td></tr></tbody></table></div><h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>log_entries</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.
-</td></tr><tr><td>total</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Total number of log entries matching the request ignoring pagination.
-</td></tr><tr><td>offset</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Echoes offset pagination parameter.
-</td></tr><tr><td>limit</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Echoes limit pagination parameter.
-</td></tr></tbody></table></div>
-<h3>Example</h3>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/log_entries"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;log_entries&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PZN9UEN&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:08:43Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHCXXHR&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-03-06T21:00:30Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PABDPAI&quot;,&#x000A;      &quot;type&quot;: &quot;resolve&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:21:15Z&quot;,&#x000A;      &quot;note&quot;: &quot;Doused it with a water hose.&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PKLZ54O&quot;,&#x000A;      &quot;type&quot;: &quot;acknowledge&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:18:13Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false,&#x000A;        &quot;type&quot;: &quot;user&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;website&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHZRXSA&quot;,&#x000A;      &quot;type&quot;: &quot;escalate&quot;,&#x000A;      &quot;created_at&quot;: &quot;2013-01-31T03:16:32Z&quot;,&#x000A;      &quot;agent&quot;: {&#x000A;        &quot;type&quot;: &quot;service&quot;&#x000A;      },&#x000A;      &quot;channel&quot;: {&#x000A;        &quot;type&quot;: &quot;timeout&quot;&#x000A;      },&#x000A;      &quot;assigned_user&quot;: {&#x000A;        &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;        &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;red&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PPSFHH7&quot;,&#x000A;        &quot;invitation_sent&quot;: true,&#x000A;        &quot;marketing_opt_out&quot;: false&#x000A;      },&#x000A;      &quot;note&quot;: null&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 5&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/:user_id/log_entries
+  </h1>
+  <p>
+    List all incident log entries that describe interactions with a specific user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/log_entries
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to <code>UTC</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end of the date range over which you want to search.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            is_overview
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            If <code>true</code>, will only return log entries of type <code>trigger</code>, <code>acknowledge</code>, or <code>resolve</code>. Defaults to <code>false</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>channel</code>, <code>incident</code>, and <code>service</code>. If <code>channel</code> is not included, a summary will be returned (See <a href="/documentation/rest/log_entries/show#channel_types">channel format information</a> for more information.)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            log_entries
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Array of the log entries. See the <a href="/documentation/rest/log_entries/show">Log Entry Show API</a> for details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            total
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Total number of log entries matching the request ignoring pagination.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            offset
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes offset pagination parameter.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            limit
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Echoes limit pagination parameter.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/log_entries"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "log_entries": [
+    {
+      "id": "PZN9UEN",
+      "type": "escalate",
+      "created_at": "2013-03-06T21:08:43Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PHCXXHR",
+      "type": "escalate",
+      "created_at": "2013-03-06T21:00:30Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    },
+    {
+      "id": "PABDPAI",
+      "type": "resolve",
+      "created_at": "2013-01-31T03:21:15Z",
+      "note": "Doused it with a water hose.",
+      "agent": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PKLZ54O",
+      "type": "acknowledge",
+      "created_at": "2013-01-31T03:18:13Z",
+      "agent": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false,
+        "type": "user"
+      },
+      "channel": {
+        "type": "website"
+      }
+    },
+    {
+      "id": "PHZRXSA",
+      "type": "escalate",
+      "created_at": "2013-01-31T03:16:32Z",
+      "agent": {
+        "type": "service"
+      },
+      "channel": {
+        "type": "timeout"
+      },
+      "assigned_user": {
+        "id": "PPSFHH7",
+        "name": "Bob Smith",
+        "email": "bob@acme.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "red",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/78e9fa7d6d2ddba416ad7534eb1403d0.png?d=mm&amp;r=PG",
+        "user_url": "/users/PPSFHH7",
+        "invitation_sent": true,
+        "marketing_opt_out": false
+      },
+      "note": null
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 5
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/maintenance_windows/create.html
+++ b/source/documentation/rest/maintenance_windows/create.html
@@ -2,17 +2,225 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/maintenance_windows">Maintenance Windows</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/maintenance_windows">Maintenance Windows</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST maintenance_windows</h1><p>Create a new maintenance window for the specified services. No new incidents will be created for a service that is currently in maintenance.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user creating the maintenance window. This is only needed if you are using token based authentication.
-</td></tr><tr><td>maintenance_window</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>The maintenance window object. See maintenance window parameters for details.
-</td></tr></tbody></table></div><h3>Maintenance Window Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start_time</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>This maintenance window's start time. This is when the services will stop creating incidents.
-If this date is in the past, it will be updated to be the current time.
-</td></tr><tr><td>end_time</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>This maintenance window's end time. This is when the services will start creating incidents again.
-This date must be in the future and after the <code>start_time</code>.
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>A description for this maintenance window.
-</td></tr><tr><td>service_ids</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>The ids of the services that are affected by this maintenance window.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "maintenance_window": {&#x000A;        "start_time": "<span class='curl_params-start_time contenteditable' contenteditable='true'>2012-06-16T13:00:00-04:00Z</span>",&#x000A;        "end_time": "<span class='curl_params-end_time contenteditable' contenteditable='true'>2012-06-16T14:00:00-04:00Z</span>",&#x000A;        "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Upgrading to new software</span>",&#x000A;        "service_ids": [&#x000A;          "<span class='curl_params-service_ids0- contenteditable' contenteditable='true'>PF9KMXH</span>"&#x000A;        ]&#x000A;      },&#x000A;      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>"&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;maintenance_window&quot;: {&#x000A;    &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;    &quot;sequence_number&quot;: 1,&#x000A;    &quot;start_time&quot;: &quot;2012-06-16T13:00:00-04:00Z&quot;,&#x000A;    &quot;end_time&quot;: &quot;2012-06-16T14:00:00-04:00Z&quot;,&#x000A;    &quot;description&quot;: &quot;This service is in maintenance due to a scheduled ruby 1.9 migration&quot;,&#x000A;    &quot;created_by&quot;: {&#x000A;      &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;      &quot;name&quot;: &quot;John Smith&quot;,&#x000A;      &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;grey20&quot;,&#x000A;      &quot;role&quot;: &quot;user&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;      &quot;invitation_sent&quot;: true&#x000A;    },&#x000A;    &quot;services&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Mail Service 12345677&quot;,&#x000A;        &quot;url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;        &quot;id&quot;: &quot;PF9KMXH&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST maintenance_windows
+  </h1>
+  <p>
+    Create a new maintenance window for the specified services. No new incidents will be created for a service that is currently in maintenance.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user creating the maintenance window. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            maintenance_window
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The maintenance window object. See maintenance window parameters for details.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Maintenance Window Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            start_time
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            This maintenance window's start time. This is when the services will stop creating incidents. If this date is in the past, it will be updated to be the current time.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end_time
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            This maintenance window's end time. This is when the services will start creating incidents again. This date must be in the future and after the <code>start_time</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A description for this maintenance window.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service_ids
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The ids of the services that are affected by this maintenance window.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "maintenance_window": {
+        "start_time": "<span class='curl_params-start_time contenteditable' contenteditable='true'>2012-06-16T13:00:00-04:00Z</span>",
+        "end_time": "<span class='curl_params-end_time contenteditable' contenteditable='true'>2012-06-16T14:00:00-04:00Z</span>",
+        "description": "<span class='curl_params-description contenteditable' contenteditable='true'>Upgrading to new software</span>",
+        "service_ids": [
+          "<span class='curl_params-service_ids0- contenteditable' contenteditable='true'>PF9KMXH</span>"
+        ]
+      },
+      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>"
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "maintenance_window": {
+    "id": "P9UJCMM",
+    "sequence_number": 1,
+    "start_time": "2012-06-16T13:00:00-04:00Z",
+    "end_time": "2012-06-16T14:00:00-04:00Z",
+    "description": "This service is in maintenance due to a scheduled ruby 1.9 migration",
+    "created_by": {
+      "id": "PP1565R",
+      "name": "John Smith",
+      "email": "john@example.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "grey20",
+      "role": "user",
+      "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+      "user_url": "/users/PP1565R",
+      "invitation_sent": true
+    },
+    "services": [
+      {
+        "name": "Mail Service 12345677",
+        "url": "/services/PF9KMXH",
+        "id": "PF9KMXH"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/maintenance_windows/delete.html
+++ b/source/documentation/rest/maintenance_windows/delete.html
@@ -2,14 +2,54 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/maintenance_windows">Maintenance Windows</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/maintenance_windows">Maintenance Windows</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE maintenance_windows/:id</h1><p>
-Remove or cancel a maintenance window. When deleting an ongoing maintenance window,
-the <code>end_time</code> will be set to now. Future maintenance windows will be deleted. Past maintenance
-windows cannot be removed or cancelled.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{}</code></pre></div>
+  <h1 class="title">
+    DELETE maintenance_windows/:id
+  </h1>
+  <p>
+    Remove or cancel a maintenance window. When deleting an ongoing maintenance window, the <code>end_time</code> will be set to now. Future maintenance windows will be deleted. Past maintenance windows cannot be removed or cancelled.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/maintenance_windows/index.html
+++ b/source/documentation/rest/maintenance_windows/index.html
@@ -2,10 +2,75 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Maintenance Windows</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Maintenance Windows
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Maintenance Windows API</h1>
-<table class="table action_index"><caption>Maintenance windows allow you to schedule service maintenance periods, during which no incidents will be created.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/maintenance_windows/list">GET maintenance_windows</a></td><td>List existing maintenance windows, optionally filtered by service, or whether they are from the past, present or future.</td></tr>
-<tr><td><a href="/documentation/rest/maintenance_windows/show">GET maintenance_windows/:id</a></td><td>Get details about an existing maintenance window.</td></tr><tr><td><a href="/documentation/rest/maintenance_windows/create">POST maintenance_windows</a></td><td>Create a new maintenance window for the specified services. No new incidents will be created for a service that is currently in maintenance.</td></tr><tr><td><a href="/documentation/rest/maintenance_windows/update">PUT maintenance_windows/:id</a></td><td>Update an existing maintenance window.</td></tr><tr><td><a href="/documentation/rest/maintenance_windows/delete">DELETE maintenance_windows/:id</a></td><td>Cancel or delete an existing maintenance window.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Maintenance Windows API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      Maintenance windows allow you to schedule service maintenance periods, during which no incidents will be created.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/maintenance_windows/list">GET maintenance_windows</a>
+        </td>
+        <td>
+          List existing maintenance windows, optionally filtered by service, or whether they are from the past, present or future.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/maintenance_windows/show">GET maintenance_windows/:id</a>
+        </td>
+        <td>
+          Get details about an existing maintenance window.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/maintenance_windows/create">POST maintenance_windows</a>
+        </td>
+        <td>
+          Create a new maintenance window for the specified services. No new incidents will be created for a service that is currently in maintenance.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/maintenance_windows/update">PUT maintenance_windows/:id</a>
+        </td>
+        <td>
+          Update an existing maintenance window.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/maintenance_windows/delete">DELETE maintenance_windows/:id</a>
+        </td>
+        <td>
+          Cancel or delete an existing maintenance window.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/maintenance_windows/list.html
+++ b/source/documentation/rest/maintenance_windows/list.html
@@ -2,14 +2,165 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/maintenance_windows">Maintenance Windows</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/maintenance_windows">Maintenance Windows</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET maintenance_windows</h1><p>List existing maintenance windows, optionally filtered by service, or whether they are from the past, present or future.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the results, showing only the maintenance windows whose descriptions contain the query.
-</td></tr><tr><td>service_ids</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>An array of service IDs, specifying services whose maintenance windows shall be returned.
-</td></tr><tr><td>filter</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Only return maintenance windows that are of this type. Possible values are
-<code>past</code>, <code>future</code>, <code>ongoing</code>. If this parameter is omitted,
-all maintenance windows will be returned.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>ruby 1.9 migration</span>" \&#x000A;    --data-urlencode "service_ids[]=<span class='curl_params-service_ids contenteditable' contenteditable='true'>PF9KMXH</span>" \&#x000A;    --data-urlencode "filter=<span class='curl_params-filter contenteditable' contenteditable='true'>ongoing</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;maintenance_windows&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;      &quot;sequence_number&quot;: 1,&#x000A;      &quot;start_time&quot;: &quot;2012-06-16T13:00:00-04:00Z&quot;,&#x000A;      &quot;end_time&quot;: &quot;2012-06-16T14:00:00-04:00Z&quot;,&#x000A;      &quot;description&quot;: &quot;This service is in maintenance due to a scheduled ruby 1.9 migration&quot;,&#x000A;      &quot;created_by&quot;: {&#x000A;        &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;        &quot;name&quot;: &quot;John Smith&quot;,&#x000A;        &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;        &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;        &quot;color&quot;: &quot;grey20&quot;,&#x000A;        &quot;role&quot;: &quot;user&quot;,&#x000A;        &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;        &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;        &quot;invitation_sent&quot;: true&#x000A;      },&#x000A;      &quot;services&quot;: [&#x000A;        {&#x000A;          &quot;name&quot;: &quot;Mail Service 12345677&quot;,&#x000A;          &quot;url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;          &quot;id&quot;: &quot;PF9KMXH&quot;&#x000A;        }&#x000A;      ]&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 1,&#x000A;  &quot;query&quot;: &quot;ruby 1.9 migration&quot;,&#x000A;  &quot;counts&quot;: {&#x000A;    &quot;ongoing&quot;: 4,&#x000A;    &quot;future&quot;: 3,&#x000A;    &quot;past&quot;: 3,&#x000A;    &quot;all&quot;: 10&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET maintenance_windows
+  </h1>
+  <p>
+    List existing maintenance windows, optionally filtered by service, or whether they are from the past, present or future.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the results, showing only the maintenance windows whose descriptions contain the query.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service_ids
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            An array of service IDs, specifying services whose maintenance windows shall be returned.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            filter
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Only return maintenance windows that are of this type. Possible values are <code>past</code>, <code>future</code>, <code>ongoing</code>. If this parameter is omitted, all maintenance windows will be returned.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>ruby 1.9 migration</span>" \
+    --data-urlencode "service_ids[]=<span class='curl_params-service_ids contenteditable' contenteditable='true'>PF9KMXH</span>" \
+    --data-urlencode "filter=<span class='curl_params-filter contenteditable' contenteditable='true'>ongoing</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "maintenance_windows": [
+    {
+      "id": "P9UJCMM",
+      "sequence_number": 1,
+      "start_time": "2012-06-16T13:00:00-04:00Z",
+      "end_time": "2012-06-16T14:00:00-04:00Z",
+      "description": "This service is in maintenance due to a scheduled ruby 1.9 migration",
+      "created_by": {
+        "id": "PP1565R",
+        "name": "John Smith",
+        "email": "john@example.com",
+        "time_zone": "Eastern Time (US &amp; Canada)",
+        "color": "grey20",
+        "role": "user",
+        "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+        "user_url": "/users/PP1565R",
+        "invitation_sent": true
+      },
+      "services": [
+        {
+          "name": "Mail Service 12345677",
+          "url": "/services/PF9KMXH",
+          "id": "PF9KMXH"
+        }
+      ]
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 1,
+  "query": "ruby 1.9 migration",
+  "counts": {
+    "ongoing": 4,
+    "future": 3,
+    "past": 3,
+    "all": 10
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/maintenance_windows/show.html
+++ b/source/documentation/rest/maintenance_windows/show.html
@@ -2,9 +2,80 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/maintenance_windows">Maintenance Windows</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/maintenance_windows">Maintenance Windows</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET maintenance_windows/:id</h1><p>Get details about an existing maintenance window.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;maintenance_window&quot;: {&#x000A;    &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;    &quot;sequence_number&quot;: 1,&#x000A;    &quot;start_time&quot;: &quot;2012-06-16T13:00:00-04:00Z&quot;,&#x000A;    &quot;end_time&quot;: &quot;2012-06-16T14:00:00-04:00Z&quot;,&#x000A;    &quot;description&quot;: &quot;This service is in maintenance due to a scheduled ruby 1.9 migration&quot;,&#x000A;    &quot;created_by&quot;: {&#x000A;      &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;      &quot;name&quot;: &quot;John Smith&quot;,&#x000A;      &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;grey20&quot;,&#x000A;      &quot;role&quot;: &quot;user&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;      &quot;invitation_sent&quot;: true&#x000A;    },&#x000A;    &quot;services&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Mail Service 12345677&quot;,&#x000A;        &quot;url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;        &quot;id&quot;: &quot;PF9KMXH&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET maintenance_windows/:id
+  </h1>
+  <p>
+    Get details about an existing maintenance window.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "maintenance_window": {
+    "id": "P9UJCMM",
+    "sequence_number": 1,
+    "start_time": "2012-06-16T13:00:00-04:00Z",
+    "end_time": "2012-06-16T14:00:00-04:00Z",
+    "description": "This service is in maintenance due to a scheduled ruby 1.9 migration",
+    "created_by": {
+      "id": "PP1565R",
+      "name": "John Smith",
+      "email": "john@example.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "grey20",
+      "role": "user",
+      "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+      "user_url": "/users/PP1565R",
+      "invitation_sent": true
+    },
+    "services": [
+      {
+        "name": "Mail Service 12345677",
+        "url": "/services/PF9KMXH",
+        "id": "PF9KMXH"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/maintenance_windows/update.html
+++ b/source/documentation/rest/maintenance_windows/update.html
@@ -2,15 +2,162 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/maintenance_windows">Maintenance Windows</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/maintenance_windows">Maintenance Windows</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT maintenance_windows/:id</h1><p>Update an existing maintenance window.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start_time</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The maintenance window's start time. Can only be updated on future maintenance windows.
-If the <code>start_time</code> is set to a date in the past, it will be updated to the current date.
-</td></tr><tr><td>end_time</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The maintenance window's end time. Can only be updated on ongoing and future maintenance windows,
-and cannot be set to a value before <code>start_time</code>.
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Description for this maintenance window. Can only be updated on ongoing and future maintenance windows.
-</td></tr><tr><td>service_ids</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Services that are affected by this maintenance window. Can only be updated on future maintenance windows.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"start_time":"<span class='curl_params-start_time contenteditable' contenteditable='true'>2012-06-16T13:00:00-04:00Z</span>","end_time":"<span class='curl_params-end_time contenteditable' contenteditable='true'>2012-06-16T14:00:00-04:00Z</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>Description goes here</span>","service_ids":["<span class='curl_params-service_ids0- contenteditable' contenteditable='true'>PF9KMXH</span>"]}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;maintenance_window&quot;: {&#x000A;    &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;    &quot;sequence_number&quot;: 1,&#x000A;    &quot;start_time&quot;: &quot;2012-06-16T13:00:00-04:00Z&quot;,&#x000A;    &quot;end_time&quot;: &quot;2012-06-16T14:00:00-04:00Z&quot;,&#x000A;    &quot;description&quot;: &quot;This service is in maintenance due to a scheduled ruby 1.9 migration&quot;,&#x000A;    &quot;created_by&quot;: {&#x000A;      &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;      &quot;name&quot;: &quot;John Smith&quot;,&#x000A;      &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;grey20&quot;,&#x000A;      &quot;role&quot;: &quot;user&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;      &quot;invitation_sent&quot;: true&#x000A;    },&#x000A;    &quot;services&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Mail Service 12345677&quot;,&#x000A;        &quot;url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;        &quot;id&quot;: &quot;PF9KMXH&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT maintenance_windows/:id
+  </h1>
+  <p>
+    Update an existing maintenance window.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/maintenance_windows/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            start_time
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The maintenance window's start time. Can only be updated on future maintenance windows. If the <code>start_time</code> is set to a date in the past, it will be updated to the current date.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end_time
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The maintenance window's end time. Can only be updated on ongoing and future maintenance windows, and cannot be set to a value before <code>start_time</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Description for this maintenance window. Can only be updated on ongoing and future maintenance windows.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service_ids
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Services that are affected by this maintenance window. Can only be updated on future maintenance windows.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"start_time":"<span class='curl_params-start_time contenteditable' contenteditable='true'>2012-06-16T13:00:00-04:00Z</span>","end_time":"<span class='curl_params-end_time contenteditable' contenteditable='true'>2012-06-16T14:00:00-04:00Z</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>Description goes here</span>","service_ids":["<span class='curl_params-service_ids0- contenteditable' contenteditable='true'>PF9KMXH</span>"]}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/maintenance_windows/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P9UJCMM</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "maintenance_window": {
+    "id": "P9UJCMM",
+    "sequence_number": 1,
+    "start_time": "2012-06-16T13:00:00-04:00Z",
+    "end_time": "2012-06-16T14:00:00-04:00Z",
+    "description": "This service is in maintenance due to a scheduled ruby 1.9 migration",
+    "created_by": {
+      "id": "PP1565R",
+      "name": "John Smith",
+      "email": "john@example.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "grey20",
+      "role": "user",
+      "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+      "user_url": "/users/PP1565R",
+      "invitation_sent": true
+    },
+    "services": [
+      {
+        "name": "Mail Service 12345677",
+        "url": "/services/PF9KMXH",
+        "id": "PF9KMXH"
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/pagination.html
+++ b/source/documentation/rest/pagination.html
@@ -5,20 +5,132 @@ permalink: /documentation/rest/pagination/
 redirect_from:
   - /documentation/rest/pagination.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Pagination</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Pagination
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">Pagination</h1>
-<p>
-Most APIs that list resources are paginated. Pagination is consistent across all APIs that require it.
-You can use the <code>offset</code> and <code>limit</code> parameters to page through query results.
-</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>offset</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The offset of the first record returned. Default is 0.
-</td></tr><tr><td>limit</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The number of records returned. Default (and max limit) is 100 for most APIs.
-</td></tr></tbody></table></div><p>
-The API response will include the <code>total</code> number of records that match this query as well
-as the <code>limit</code> and <code>offset</code> actually used.
-</p>
-<h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>offset</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The offset used in the execution of the query.
-</td></tr><tr><td>limit</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The limit used in the execution of the query.
-</td></tr><tr><td>total</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The total number of records available.
-</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    Pagination
+  </h1>
+  <p>
+    Most APIs that list resources are paginated. Pagination is consistent across all APIs that require it. You can use the <code>offset</code> and <code>limit</code> parameters to page through query results.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            offset
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The offset of the first record returned. Default is 0.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            limit
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The number of records returned. Default (and max limit) is 100 for most APIs.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p>
+    The API response will include the <code>total</code> number of records that match this query as well as the <code>limit</code> and <code>offset</code> actually used.
+  </p>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            offset
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The offset used in the execution of the query.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            limit
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The limit used in the execution of the query.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            total
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The total number of records available.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/reports/alerts_per_time.html
+++ b/source/documentation/rest/reports/alerts_per_time.html
@@ -2,20 +2,152 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/reports">Reports</a></li><span class="divider">/</span><li>Alerts Per Time</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/reports">Reports</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Alerts Per Time
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET reports/alerts_per_time</h1><p>Get high level statistics about the number of alerts (SMSes, phone calls and emails) sent for the desired time period, summed daily, weekly or monthly.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/reports/alerts_per_time</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start of the date range over which you want to search. The time element is optional.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end of the date range over which you want to search. This should be in the same format as <code>since</code>.
-</td></tr><tr><td>rollup</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>
-Possible values are <code>daily</code>, <code>weekly</code> or <code>monthly</code>.
-Specifies the bucket duration for each summation. Defaults to <code>monthly</code>.
-</p>
-<p>
-<strong>Example:</strong> A time window of two years (based on <code>since</code> and <code>until</code>) with a
-rollup of <code>monthly</code> will result in 24 sets of data points being returned (one for each month in the span).
-</p>
-</td></tr>
-</tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-01</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/reports/alerts_per_time"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;alerts&quot;: [&#x000A;    {&#x000A;      &quot;number_of_alerts&quot;: 17,&#x000A;      &quot;number_of_phone_alerts&quot;: 11,&#x000A;      &quot;number_of_sms_alerts&quot;: 2,&#x000A;      &quot;number_of_email_alerts&quot;: 4,&#x000A;      &quot;start&quot;: &quot;2012-06-01T07:00:00Z&quot;,&#x000A;      &quot;end&quot;: &quot;2012-07-01T00:00:00-07:00&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;number_of_alerts&quot;: 22,&#x000A;      &quot;number_of_phone_alerts&quot;: 12,&#x000A;      &quot;number_of_sms_alerts&quot;: 5,&#x000A;      &quot;number_of_email_alerts&quot;: 5,&#x000A;      &quot;start&quot;: &quot;2012-07-01T07:00:00Z&quot;,&#x000A;      &quot;end&quot;: &quot;2012-08-01T00:00:00-07:00&quot;&#x000A;    }&#x000A;  ],&#x000A;  &quot;total_number_of_alerts&quot;: 39,&#x000A;  &quot;total_number_of_phone_alerts&quot;: 23,&#x000A;  &quot;total_number_of_sms_alerts&quot;: 7,&#x000A;  &quot;total_number_of_email_alerts&quot;: 9,&#x000A;  &quot;total_number_of_billable_alerts&quot;: 30&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET reports/alerts_per_time
+  </h1>
+  <p>
+    Get high level statistics about the number of alerts (SMSes, phone calls and emails) sent for the desired time period, summed daily, weekly or monthly.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/reports/alerts_per_time
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start of the date range over which you want to search. The time element is optional.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The end of the date range over which you want to search. This should be in the same format as <code>since</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rollup
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Possible values are <code>daily</code>, <code>weekly</code> or <code>monthly</code>. Specifies the bucket duration for each summation. Defaults to <code>monthly</code>.
+            </p>
+            <p>
+              <strong>Example:</strong> A time window of two years (based on <code>since</code> and <code>until</code>) with a rollup of <code>monthly</code> will result in 24 sets of data points being returned (one for each month in the span).
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-01</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/reports/alerts_per_time"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "alerts": [
+    {
+      "number_of_alerts": 17,
+      "number_of_phone_alerts": 11,
+      "number_of_sms_alerts": 2,
+      "number_of_email_alerts": 4,
+      "start": "2012-06-01T07:00:00Z",
+      "end": "2012-07-01T00:00:00-07:00"
+    },
+    {
+      "number_of_alerts": 22,
+      "number_of_phone_alerts": 12,
+      "number_of_sms_alerts": 5,
+      "number_of_email_alerts": 5,
+      "start": "2012-07-01T07:00:00Z",
+      "end": "2012-08-01T00:00:00-07:00"
+    }
+  ],
+  "total_number_of_alerts": 39,
+  "total_number_of_phone_alerts": 23,
+  "total_number_of_sms_alerts": 7,
+  "total_number_of_email_alerts": 9,
+  "total_number_of_billable_alerts": 30
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/reports/incidents_per_time.html
+++ b/source/documentation/rest/reports/incidents_per_time.html
@@ -2,20 +2,152 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/reports">Reports</a></li><span class="divider">/</span><li>Incidents Per Time</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/reports">Reports</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Incidents Per Time
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET reports/incidents_per_time</h1><p>Get high level statistics about the number of incidents created for the desired time period, summed daily, weekly or monthly.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/reports/incidents_per_time/</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start of the date range over which you want to search. The time element is optional.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end of the date range over which you want to search. This should be in the same format as <code>since</code>.
-</td></tr><tr><td>rollup</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>
-Possible values are <code>daily</code>, <code>weekly</code> or <code>monthly</code>.
-Specifies the bucket duration for each summation. Defaults to <code>monthly</code>.
-</p>
-<p>
-<strong>Example:</strong> A time window of two years (based on <code>since</code> and <code>until</code>) with a
-rollup of <code>monthly</code> will result in 24 sets of data points being returned (one for each month in the span).
-</p>
-</td></tr>
-</tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-01T00:00:00Z</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-05T00:00:00Z</span>" \&#x000A;    --data-urlencode "rollup=<span class='curl_params-rollup contenteditable' contenteditable='true'>daily</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/reports/incidents_per_time/"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;incidents&quot;: [&#x000A;    {&#x000A;      &quot;start&quot;: &quot;2012-08-01T00:00:00Z&quot;,&#x000A;      &quot;number_of_incidents&quot;: 7,&#x000A;      &quot;end&quot;: &quot;2012-08-02T00:00:00Z&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;start&quot;: &quot;2012-08-02T00:00:00Z&quot;,&#x000A;      &quot;number_of_incidents&quot;: 3,&#x000A;      &quot;end&quot;: &quot;2012-08-03T00:00:00Z&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;start&quot;: &quot;2012-08-03T00:00:00Z&quot;,&#x000A;      &quot;number_of_incidents&quot;: 4,&#x000A;      &quot;end&quot;: &quot;2012-08-04T00:00:00Z&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;start&quot;: &quot;2012-08-04T00:00:00Z&quot;,&#x000A;      &quot;number_of_incidents&quot;: 15,&#x000A;      &quot;end&quot;: &quot;2012-08-05T00:00:00Z&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET reports/incidents_per_time
+  </h1>
+  <p>
+    Get high level statistics about the number of incidents created for the desired time period, summed daily, weekly or monthly.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/reports/incidents_per_time/
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start of the date range over which you want to search. The time element is optional.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The end of the date range over which you want to search. This should be in the same format as <code>since</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rollup
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Possible values are <code>daily</code>, <code>weekly</code> or <code>monthly</code>. Specifies the bucket duration for each summation. Defaults to <code>monthly</code>.
+            </p>
+            <p>
+              <strong>Example:</strong> A time window of two years (based on <code>since</code> and <code>until</code>) with a rollup of <code>monthly</code> will result in 24 sets of data points being returned (one for each month in the span).
+            </p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-01T00:00:00Z</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-05T00:00:00Z</span>" \
+    --data-urlencode "rollup=<span class='curl_params-rollup contenteditable' contenteditable='true'>daily</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/reports/incidents_per_time/"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "incidents": [
+    {
+      "start": "2012-08-01T00:00:00Z",
+      "number_of_incidents": 7,
+      "end": "2012-08-02T00:00:00Z"
+    },
+    {
+      "start": "2012-08-02T00:00:00Z",
+      "number_of_incidents": 3,
+      "end": "2012-08-03T00:00:00Z"
+    },
+    {
+      "start": "2012-08-03T00:00:00Z",
+      "number_of_incidents": 4,
+      "end": "2012-08-04T00:00:00Z"
+    },
+    {
+      "start": "2012-08-04T00:00:00Z",
+      "number_of_incidents": 15,
+      "end": "2012-08-05T00:00:00Z"
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/reports/index.html
+++ b/source/documentation/rest/reports/index.html
@@ -2,10 +2,51 @@
 title: Reports API
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Reports</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Reports
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Reports API</h1>
-<table class="table action_index"><caption>Access high level reports about alerts and incidents. Useful for creating graphs.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/reports/alerts_per_time">GET alerts_per_time</a></td><td>Get high level statistics about the number of alerts (SMSes, phone calls and emails) sent for the desired time period, summed daily, weekly or monthly.</td></tr>
-<tr><td><a href="/documentation/rest/reports/incidents_per_time">GET incidents_per_time</a></td><td>Get high level statistics about the number of incidents created for the desired time period, summed daily, weekly or monthly.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Reports API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      Access high level reports about alerts and incidents. Useful for creating graphs.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/reports/alerts_per_time">GET alerts_per_time</a>
+        </td>
+        <td>
+          Get high level statistics about the number of alerts (SMSes, phone calls and emails) sent for the desired time period, summed daily, weekly or monthly.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/reports/incidents_per_time">GET incidents_per_time</a>
+        </td>
+        <td>
+          Get high level statistics about the number of incidents created for the desired time period, summed daily, weekly or monthly.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/schedules/create.html
+++ b/source/documentation/rest/schedules/create.html
@@ -2,51 +2,531 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Create</li></ul>
-<h1 class="title">POST schedules</h1><p>Create a new on-call schedule.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>overflow</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td><p>
-Any on-call schedule entries that pass the date range bounds will be truncated at the
-bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
-</p>
-<p>
-For instance, if your schedule is a rotation that changes daily at midnight UTC, and
-your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
-</p>
-<ul>
-<li>
-If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code>
-of <code>2011-06-01T14:00:00Z</code>.
-</li>
-<li>
-If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code>
-of <code>2011-06-02T00:00:00Z</code>.
-</li>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
 </ul>
-</td></tr>
-<tr><td>schedule</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>The schedule object. See schedule parameters for details.
-</td></tr></tbody></table></div><h3>Schedule Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>schedule_layers</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>A list of schedule layers. See the schedule layers parameters for details.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>Yes</td><td>The time zone of the schedule.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the schedule
-</td></tr></tbody></table></div><h3>Schedule Layer Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start time of this layer.
-</td></tr><tr><td>end</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end time of this layer. If null, the layer does not end.
-</td></tr><tr><td>users</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td><p>
-The ordered list of users on this layer. Use the member order to indicate their order.
+<h1 class="title">
+  POST schedules
+</h1>
+<p>
+  Create a new on-call schedule.
 </p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;P2BI1SS&quot;&#x000A;      },&#x000A;      &quot;member_order&quot;: 1&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>restriction_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Can either be <code>Daily</code> or <code>Weekly</code>. Specify the types of <code>restriction</code>.
-</td></tr><tr><td>restrictions</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td><p>
-An array of restrictions for the layer. A restriction is a limit on which period of the
-day or week the schedule layer can accept events.
+<h3>
+  Resource URL
+</h3>
+<div class="prism action-url language-bash">
+  <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules
+</pre>
+</div>
+<h3>
+  Parameters
+</h3>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Name
+        </th>
+        <th>
+          Type
+        </th>
+        <th>
+          Required
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          overflow
+        </td>
+        <td>
+          <a href="/documentation/rest/types#boolean">Boolean</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <p>
+            Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
+          </p>
+          <p>
+            For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
+          </p>
+          <ul>
+            <li>If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code> of <code>2011-06-01T14:00:00Z</code>.
+            </li>
+            <li>If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code> of <code>2011-06-02T00:00:00Z</code>.
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          schedule
+        </td>
+        <td>
+          <a href="/documentation/rest/types#object">Object</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          The schedule object. See schedule parameters for details.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<h3>
+  Schedule Parameters
+</h3>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Name
+        </th>
+        <th>
+          Type
+        </th>
+        <th>
+          Required
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          schedule_layers
+        </td>
+        <td>
+          <a href="/documentation/rest/types#array">Array</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          A list of schedule layers. See the schedule layers parameters for details.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          time_zone
+        </td>
+        <td>
+          <a href="/documentation/rest/types#timezone">Time Zone</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The time zone of the schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          name
+        </td>
+        <td>
+          <a href="/documentation/rest/types#string">String</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The name of the schedule
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<h3>
+  Schedule Layer Parameters
+</h3>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Name
+        </th>
+        <th>
+          Type
+        </th>
+        <th>
+          Required
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          start
+        </td>
+        <td>
+          <a href="/documentation/rest/types#datetime">Date</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The start time of this layer.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          end
+        </td>
+        <td>
+          <a href="/documentation/rest/types#datetime">Date</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          The end time of this layer. If null, the layer does not end.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          users
+        </td>
+        <td>
+          <a href="/documentation/rest/types#array">Array</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          <p>
+            The ordered list of users on this layer. Use the member order to indicate their order.
+          </p>
+          <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "user": {
+        "id": "P2BI1SS"
+      },
+      "member_order": 1
+    }
+  ]
+}</code>
+</pre>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          restriction_type
+        </td>
+        <td>
+          <a href="/documentation/rest/types#string">String</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Can either be <code>Daily</code> or <code>Weekly</code>. Specify the types of <code>restriction</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          restrictions
+        </td>
+        <td>
+          <a href="/documentation/rest/types#array">Array</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <p>
+            An array of restrictions for the layer. A restriction is a limit on which period of the day or week the schedule layer can accept events.
+          </p>
+          <pre>
+<code class="language-javascript prettyprint linenums">{
+  "restrictions": [
+    {
+      "duration_seconds": 43200,
+      "start_time_of_day": "00:00:00"
+    }
+  ]
+}</code>
+</pre>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          rotation_virtual_start
+        </td>
+        <td>
+          <a href="/documentation/rest/types#datetime">Date</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The effective start time of the layer. This can be before the start time of the schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          priority
+        </td>
+        <td>
+          <a href="/documentation/rest/types#int">Integer</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The priority of the layer. Layers with higher priority will override layers with a lower priority.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          rotation_turn_length_seconds
+        </td>
+        <td>
+          <a href="/documentation/rest/types#int">Integer</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The duration of each on-call shift in seconds.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          name
+        </td>
+        <td>
+          <a href="/documentation/rest/types#string">String</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          The name of the schedule layer.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<h3>
+  Example
+</h3>
+<p>
+  Let's create this shedule:
+</p><img alt="Schedule_create" src="/assets/images/schedule_create.png">
+<pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "since": "<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+      "overflow": 1,
+      "until": "<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-19T00:00:00</span>",
+      "schedule": {
+        "schedule_layers": [
+          {
+            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "users": [
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P2BI1SS</span>"
+                },
+                "member_order": 1
+              },
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PX3ILJ6</span>"
+                },
+                "member_order": 2
+              }
+            ],
+            "restriction_type": null,
+            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "priority": 0,
+            "rotation_turn_length_seconds": 604800,
+            "end": null,
+            "restrictions": [
+    
+            ],
+            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>"
+          },
+          {
+            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "users": [
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PAD6MYW</span>"
+                },
+                "member_order": 1
+              },
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PU6348I</span>"
+                },
+                "member_order": 2
+              },
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P6O624F</span>"
+                },
+                "member_order": 3
+              }
+            ],
+            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",
+            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "rotation_turn_length_seconds": 86400,
+            "priority": 1,
+            "restrictions": [
+              {
+                "duration_seconds": 43200,
+                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"
+              }
+            ],
+            "end": null,
+            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 2</span>"
+          }
+        ],
+        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>Eastern Time (US &amp; Canada)</span>",
+        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Primary On-Call Schedule</span>"
+      }
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules"</code>
+</pre>
+<p class="content-type-warning clearfix">
+  Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
 </p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;restrictions&quot;: [&#x000A;    {&#x000A;      &quot;duration_seconds&quot;: 43200,&#x000A;      &quot;start_time_of_day&quot;: &quot;00:00:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>rotation_virtual_start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The effective start time of the layer. This can be before the start time of the schedule.
-</td></tr><tr><td>priority</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The priority of the layer. Layers with higher priority will override layers with a lower priority.
-</td></tr><tr><td>rotation_turn_length_seconds</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The duration of each on-call shift in seconds.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the schedule layer.
-</td></tr></tbody></table></div><h3>Example</h3>
-<p>Let's create this shedule:</p>
-<img alt="Schedule_create" src="/assets/images/schedule_create.png"/>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "since": "<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;      "overflow": 1,&#x000A;      "until": "<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-19T00:00:00</span>",&#x000A;      "schedule": {&#x000A;        "schedule_layers": [&#x000A;          {&#x000A;            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "users": [&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P2BI1SS</span>"&#x000A;                },&#x000A;                "member_order": 1&#x000A;              },&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PX3ILJ6</span>"&#x000A;                },&#x000A;                "member_order": 2&#x000A;              }&#x000A;            ],&#x000A;            "restriction_type": null,&#x000A;            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "priority": 0,&#x000A;            "rotation_turn_length_seconds": 604800,&#x000A;            "end": null,&#x000A;            "restrictions": [&#x000A;    &#x000A;            ],&#x000A;            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>"&#x000A;          },&#x000A;          {&#x000A;            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "users": [&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PAD6MYW</span>"&#x000A;                },&#x000A;                "member_order": 1&#x000A;              },&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PU6348I</span>"&#x000A;                },&#x000A;                "member_order": 2&#x000A;              },&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P6O624F</span>"&#x000A;                },&#x000A;                "member_order": 3&#x000A;              }&#x000A;            ],&#x000A;            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",&#x000A;            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "rotation_turn_length_seconds": 86400,&#x000A;            "priority": 1,&#x000A;            "restrictions": [&#x000A;              {&#x000A;                "duration_seconds": 43200,&#x000A;                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"&#x000A;              }&#x000A;            ],&#x000A;            "end": null,&#x000A;            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 2</span>"&#x000A;          }&#x000A;        ],&#x000A;        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>Eastern Time (US &amp; Canada)</span>",&#x000A;        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Primary On-Call Schedule</span>"&#x000A;      }&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;schedule&quot;: {&#x000A;    &quot;schedule_layers&quot;: [&#x000A;      {&#x000A;        &quot;restriction_type&quot;: null,&#x000A;        &quot;priority&quot;: 0,&#x000A;        &quot;start&quot;: &quot;2012-08-05T00:00:00-04:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 604800,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2012-08-05T00:00:00-04:00&quot;,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;email&quot;: &quot;hailie_hansen@shieldsfarrell.biz&quot;,&#x000A;              &quot;color&quot;: &quot;orange&quot;,&#x000A;              &quot;id&quot;: &quot;P2BI1SS&quot;,&#x000A;              &quot;name&quot;: &quot;Hailie Hansen&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 1&#x000A;          },&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;email&quot;: &quot;rogahn.karl@cole.info&quot;,&#x000A;              &quot;color&quot;: &quot;orange-red&quot;,&#x000A;              &quot;id&quot;: &quot;PX3ILJ6&quot;,&#x000A;              &quot;name&quot;: &quot;Karl Rogahn&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 2&#x000A;          }&#x000A;        ],&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;id&quot;: &quot;PZGJA4R&quot;,&#x000A;        &quot;restrictions&quot;: [&#x000A;&#x000A;        ],&#x000A;        &quot;name&quot;: &quot;Schedule Layer 1&quot;&#x000A;      },&#x000A;      {&#x000A;        &quot;restriction_type&quot;: &quot;Daily&quot;,&#x000A;        &quot;priority&quot;: 1,&#x000A;        &quot;start&quot;: &quot;2012-08-05T00:00:00-04:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 86400,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2012-08-05T00:00:00-04:00&quot;,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;email&quot;: &quot;gabrielle_glover@mertz.biz&quot;,&#x000A;              &quot;color&quot;: &quot;cayenne&quot;,&#x000A;              &quot;id&quot;: &quot;PAD6MYW&quot;,&#x000A;              &quot;name&quot;: &quot;Gabrielle Glover&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 1&#x000A;          },&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;email&quot;: &quot;gerhard.abernathy@kulas.us&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;,&#x000A;              &quot;id&quot;: &quot;PU6348I&quot;,&#x000A;              &quot;name&quot;: &quot;Gerhard Abernathy&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 2&#x000A;          },&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;email&quot;: &quot;gregory_hilll@deckow.us&quot;,&#x000A;              &quot;color&quot;: &quot;teal&quot;,&#x000A;              &quot;id&quot;: &quot;P6O624F&quot;,&#x000A;              &quot;name&quot;: &quot;Gregory Hilll&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 3&#x000A;          }&#x000A;        ],&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;id&quot;: &quot;PW7YZS1&quot;,&#x000A;        &quot;restrictions&quot;: [&#x000A;          {&#x000A;            &quot;duration_seconds&quot;: 43200,&#x000A;            &quot;start_time_of_day&quot;: &quot;00:00:00&quot;&#x000A;          }&#x000A;        ],&#x000A;        &quot;name&quot;: &quot;Schedule Layer 2&quot;&#x000A;      }&#x000A;    ],&#x000A;    &quot;final_schedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Final Schedule&quot;&#x000A;    },&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;escalation_policies&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;today&quot;: &quot;2012-08-08&quot;,&#x000A;    &quot;overrides_subschedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Overrides&quot;&#x000A;    },&#x000A;    &quot;name&quot;: &quot;Primary On-Call Schedule&quot;&#x000A;  },&#x000A;  &quot;id&quot;: &quot;P2BI1SS&quot;&#x000A;}</code></pre></div>
+<div class="clearfix"></div>
+<h4>
+  Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+</h4>
+<div class="response">
+  <pre>
+<code class="language-javascript prettyprint linenums">{
+  "schedule": {
+    "schedule_layers": [
+      {
+        "restriction_type": null,
+        "priority": 0,
+        "start": "2012-08-05T00:00:00-04:00",
+        "rotation_turn_length_seconds": 604800,
+        "rotation_virtual_start": "2012-08-05T00:00:00-04:00",
+        "users": [
+          {
+            "user": {
+              "email": "hailie_hansen@shieldsfarrell.biz",
+              "color": "orange",
+              "id": "P2BI1SS",
+              "name": "Hailie Hansen"
+            },
+            "member_order": 1
+          },
+          {
+            "user": {
+              "email": "rogahn.karl@cole.info",
+              "color": "orange-red",
+              "id": "PX3ILJ6",
+              "name": "Karl Rogahn"
+            },
+            "member_order": 2
+          }
+        ],
+        "end": null,
+        "id": "PZGJA4R",
+        "restrictions": [
+
+        ],
+        "name": "Schedule Layer 1"
+      },
+      {
+        "restriction_type": "Daily",
+        "priority": 1,
+        "start": "2012-08-05T00:00:00-04:00",
+        "rotation_turn_length_seconds": 86400,
+        "rotation_virtual_start": "2012-08-05T00:00:00-04:00",
+        "users": [
+          {
+            "user": {
+              "email": "gabrielle_glover@mertz.biz",
+              "color": "cayenne",
+              "id": "PAD6MYW",
+              "name": "Gabrielle Glover"
+            },
+            "member_order": 1
+          },
+          {
+            "user": {
+              "email": "gerhard.abernathy@kulas.us",
+              "color": "red",
+              "id": "PU6348I",
+              "name": "Gerhard Abernathy"
+            },
+            "member_order": 2
+          },
+          {
+            "user": {
+              "email": "gregory_hilll@deckow.us",
+              "color": "teal",
+              "id": "P6O624F",
+              "name": "Gregory Hilll"
+            },
+            "member_order": 3
+          }
+        ],
+        "end": null,
+        "id": "PW7YZS1",
+        "restrictions": [
+          {
+            "duration_seconds": 43200,
+            "start_time_of_day": "00:00:00"
+          }
+        ],
+        "name": "Schedule Layer 2"
+      }
+    ],
+    "final_schedule": {
+      "name": "Final Schedule"
+    },
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "escalation_policies": [
+
+    ],
+    "today": "2012-08-08",
+    "overrides_subschedule": {
+      "name": "Overrides"
+    },
+    "name": "Primary On-Call Schedule"
+  },
+  "id": "P2BI1SS"
+}</code>
+</pre>
+</div>

--- a/source/documentation/rest/schedules/delete.html
+++ b/source/documentation/rest/schedules/delete.html
@@ -2,7 +2,48 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Delete</li></ul>
-<h1 class="title">DELETE schedules/:id</h1><p>Delete an on-call schedule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
+<h1 class="title">
+  DELETE schedules/:id
+</h1>
+<p>
+  Delete an on-call schedule.
+</p>
+<h3>
+  Resource URL
+</h3>
+<div class="prism action-url language-bash">
+  <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+</div>
+<h3>
+  Example
+</h3>
+<pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+<p class="content-type-warning clearfix">
+  Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+</p>
+<div class="clearfix"></div>
+<h4>
+  Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+</h4>
+<div class="response"></div>

--- a/source/documentation/rest/schedules/entries.html
+++ b/source/documentation/rest/schedules/entries.html
@@ -2,40 +2,263 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Entries</li></ul>
-<h1 class="title">GET schedules/:id/entries</h1><p>List schedule entries that are active for a given time range for a specified on-call schedule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>/entries</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td><p>The start of the date range over which you want to return on-call schedule entries.</p>
-<p>The maximum range queryable at once is <strong>three months</strong>.</p>
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end of the date range over which you want to return schedule entries.
-</td></tr><tr><td>overflow</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td><p>
-Any on-call schedule entries that pass the date range bounds will be truncated at the
-bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
-</p>
-<p>
-For instance, if your schedule is a rotation that changes daily at midnight UTC, and
-your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
-</p>
-<ul>
-<li>
-If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code>
-of <code>2011-06-01T14:00:00Z</code>.
-</li>
-<li>
-If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code>
-of <code>2011-06-02T00:00:00Z</code>.
-</li>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Entries
+  </li>
 </ul>
-</td></tr>
-<tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to account time zone.
-</td></tr><tr><td>user_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>To filter the returned on-call schedule entries by a specific user, you can optionally
-add the <code>user_id</code> parameter to the query.
-</td></tr></tbody></table></div><h3>Examples</h3>
-<h4>Fetch the on-call schedule for the next day.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-08-19</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-08-20</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P4MHU96</span>/entries"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;total&quot;: 3,&#x000A;  &quot;entries&quot;: [&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;email&quot;: &quot;gregory_hilll@deckow.us&quot;,&#x000A;        &quot;name&quot;: &quot;Gregory&quot;,&#x000A;        &quot;color&quot;: &quot;chocolate&quot;,&#x000A;        &quot;id&quot;: &quot;PRT2T0A&quot;&#x000A;      },&#x000A;      &quot;end&quot;: &quot;2012-08-19T12:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-08-19T00:00:00-04:00&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;email&quot;: &quot;hailie_hansen@shieldsfarrell.biz&quot;,&#x000A;        &quot;name&quot;: &quot;Halie&quot;,&#x000A;        &quot;color&quot;: &quot;maroon&quot;,&#x000A;        &quot;id&quot;: &quot;PFKNVH3&quot;&#x000A;      },&#x000A;      &quot;end&quot;: &quot;2012-08-20T00:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-08-19T12:00:00-04:00&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;email&quot;: &quot;gabrielle_glover@mertz.biz&quot;,&#x000A;        &quot;name&quot;: &quot;Gabriel&quot;,&#x000A;        &quot;color&quot;: &quot;dark-red&quot;,&#x000A;        &quot;id&quot;: &quot;PYBBUSQ&quot;&#x000A;      },&#x000A;      &quot;end&quot;: &quot;2012-08-20T00:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-08-20T00:00:00-04:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
-<h4>Find out who is on-call at 2pm UTC today, but include the start and end time of their entire shift.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-08-19T14:00:00Z</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-08-19T14:00:00Z</span>" \&#x000A;    --data-urlencode "overflow=true" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P4MHU96</span>/entries"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;total&quot;: 1,&#x000A;  &quot;entries&quot;: [&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;email&quot;: &quot;gregory_hilll@deckow.us&quot;,&#x000A;        &quot;name&quot;: &quot;Gregory&quot;,&#x000A;        &quot;color&quot;: &quot;chocolate&quot;,&#x000A;        &quot;id&quot;: &quot;PRT2T0A&quot;&#x000A;      },&#x000A;      &quot;end&quot;: &quot;2012-08-19T12:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-08-19T00:00:00-04:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
-<div class="errors well"><h4>Errors</h4><div class="table-container"><table class="table table-striped"><thead><th>Code</th><th>Message</th></thead><tbody><tr><td>3004</td><td>Unknown Schedule</td></tr>
-</tbody></table></div></div>
+<h1 class="title">
+  GET schedules/:id/entries
+</h1>
+<p>
+  List schedule entries that are active for a given time range for a specified on-call schedule.
+</p>
+<h3>
+  Resource URL
+</h3>
+<div class="prism action-url language-bash">
+  <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>/entries
+</pre>
+</div>
+<h3>
+  Parameters
+</h3>
+<div class="table-container">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          Name
+        </th>
+        <th>
+          Type
+        </th>
+        <th>
+          Required
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          since
+        </td>
+        <td>
+          <a href="/documentation/rest/types#datetime">Date</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          <p>
+            The start of the date range over which you want to return on-call schedule entries.
+          </p>
+          <p>
+            The maximum range queryable at once is <strong>three months</strong>.
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          until
+        </td>
+        <td>
+          <a href="/documentation/rest/types#datetime">Date</a>
+        </td>
+        <td>
+          Yes
+        </td>
+        <td>
+          The end of the date range over which you want to return schedule entries.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          overflow
+        </td>
+        <td>
+          <a href="/documentation/rest/types#boolean">Boolean</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          <p>
+            Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
+          </p>
+          <p>
+            For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
+          </p>
+          <ul>
+            <li>If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code> of <code>2011-06-01T14:00:00Z</code>.
+            </li>
+            <li>If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code> of <code>2011-06-02T00:00:00Z</code>.
+            </li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          time_zone
+        </td>
+        <td>
+          <a href="/documentation/rest/types#timezone">Time Zone</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          Time zone in which dates in the result will be rendered. Defaults to account time zone.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          user_id
+        </td>
+        <td>
+          <a href="/documentation/rest/types#string">String</a>
+        </td>
+        <td>
+          No
+        </td>
+        <td>
+          To filter the returned on-call schedule entries by a specific user, you can optionally add the <code>user_id</code> parameter to the query.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<h3>
+  Examples
+</h3>
+<h4>
+  Fetch the on-call schedule for the next day.
+</h4>
+<pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-08-19</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-08-20</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P4MHU96</span>/entries"</code>
+</pre>
+<p class="content-type-warning clearfix">
+  Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+</p>
+<div class="clearfix"></div>
+<h4>
+  Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+</h4>
+<div class="response">
+  <pre>
+<code class="language-javascript prettyprint linenums">{
+  "total": 3,
+  "entries": [
+    {
+      "user": {
+        "email": "gregory_hilll@deckow.us",
+        "name": "Gregory",
+        "color": "chocolate",
+        "id": "PRT2T0A"
+      },
+      "end": "2012-08-19T12:00:00-04:00",
+      "start": "2012-08-19T00:00:00-04:00"
+    },
+    {
+      "user": {
+        "email": "hailie_hansen@shieldsfarrell.biz",
+        "name": "Halie",
+        "color": "maroon",
+        "id": "PFKNVH3"
+      },
+      "end": "2012-08-20T00:00:00-04:00",
+      "start": "2012-08-19T12:00:00-04:00"
+    },
+    {
+      "user": {
+        "email": "gabrielle_glover@mertz.biz",
+        "name": "Gabriel",
+        "color": "dark-red",
+        "id": "PYBBUSQ"
+      },
+      "end": "2012-08-20T00:00:00-04:00",
+      "start": "2012-08-20T00:00:00-04:00"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<h4>
+  Find out who is on-call at 2pm UTC today, but include the start and end time of their entire shift.
+</h4>
+<pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2011-08-19T14:00:00Z</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2011-08-19T14:00:00Z</span>" \
+    --data-urlencode "overflow=true" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P4MHU96</span>/entries"</code>
+</pre>
+<h4>
+  Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+</h4>
+<div class="response">
+  <pre>
+<code class="language-javascript prettyprint linenums">{
+  "total": 1,
+  "entries": [
+    {
+      "user": {
+        "email": "gregory_hilll@deckow.us",
+        "name": "Gregory",
+        "color": "chocolate",
+        "id": "PRT2T0A"
+      },
+      "end": "2012-08-19T12:00:00-04:00",
+      "start": "2012-08-19T00:00:00-04:00"
+    }
+  ]
+}</code>
+</pre>
+</div>
+<div class="errors well">
+  <h4>
+    Errors
+  </h4>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Code
+          </th>
+          <th>
+            Message
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            3004
+          </td>
+          <td>
+            Unknown Schedule
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/schedules/index.html
+++ b/source/documentation/rest/schedules/index.html
@@ -2,20 +2,108 @@
 title: Schedules API
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Schedules</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Schedules
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Schedules API</h1>
-On call schedules determine the time periods that users are on-call. Only when a user is on-call he is eligible to receive alerts from <a href="/documentation/rest/incidents">incidents</a>.
-<table class="table action_index"><caption>This API allows users to manipulate on-call schedules.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/schedules/list">GET schedules</a></td><td>List existing on-call schedules.</td></tr><tr><td><a href="/documentation/rest/schedules/show">GET schedules/:id</a></td><td>Show detailed information about a schedule, including entries for each layer and sub-schedule.</td></tr>
-<tr><td><a href="/documentation/rest/schedules/users">GET schedules/:id/users</a></td><td>List all the users on-call in a given schedule for a given time range.</td></tr>
-<tr><td><a href="/documentation/rest/schedules/create">POST schedules</a></td><td>Create a new on-call schedule.</td></tr><tr><td><a href="/documentation/rest/schedules/update">PUT schedules/:id</a></td><td>Update an existing on-call schedule.</td></tr>
-<tr><td><a href="/documentation/rest/schedules/preview">POST schedules/preview</a></td><td>Preview the configuration of an on-call schedule.</td></tr>
-<tr><td><a href="/documentation/rest/schedules/delete">DELETE schedules/:id</a></td><td>Delete an on-call schedule.</td></tr>
-<tr><td><a href="/documentation/rest/schedules/entries">GET schedules/:id/entries</a></td><td>List schedule entries that are active for a given time range for a specified on-call schedule.</td></tr>
-</tbody></table><div class="row-fluid pro-tip"><div class="span2 label label-info">Pro Tip</div><div class="span9"><strong>Going on vacation?</strong>
-<strong>Standard schedule layering not cutting it for you?</strong>
-<br>
-Check out the <a href="/documentation/rest/schedules/overrides">Schedule Overrides API</a>
-for setting up exceptions to your on-call schedules.
-</div></div></div>
+  <h1 class="title">
+    Schedules API
+  </h1>On call schedules determine the time periods that users are on-call. Only when a user is on-call he is eligible to receive alerts from <a href="/documentation/rest/incidents">incidents</a>.
+  <table class="table action_index">
+    <caption>
+      This API allows users to manipulate on-call schedules.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/list">GET schedules</a>
+        </td>
+        <td>
+          List existing on-call schedules.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/show">GET schedules/:id</a>
+        </td>
+        <td>
+          Show detailed information about a schedule, including entries for each layer and sub-schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/users">GET schedules/:id/users</a>
+        </td>
+        <td>
+          List all the users on-call in a given schedule for a given time range.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/create">POST schedules</a>
+        </td>
+        <td>
+          Create a new on-call schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/update">PUT schedules/:id</a>
+        </td>
+        <td>
+          Update an existing on-call schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/preview">POST schedules/preview</a>
+        </td>
+        <td>
+          Preview the configuration of an on-call schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/delete">DELETE schedules/:id</a>
+        </td>
+        <td>
+          Delete an on-call schedule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/entries">GET schedules/:id/entries</a>
+        </td>
+        <td>
+          List schedule entries that are active for a given time range for a specified on-call schedule.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="row-fluid pro-tip">
+    <div class="span2 label label-info">
+      Pro Tip
+    </div>
+    <div class="span9">
+      <strong>Going on vacation?</strong> <strong>Standard schedule layering not cutting it for you?</strong><br>
+      Check out the <a href="/documentation/rest/schedules/overrides">Schedule Overrides API</a> for setting up exceptions to your on-call schedules.
+    </div>
+  </div>
+</div>

--- a/source/documentation/rest/schedules/list.html
+++ b/source/documentation/rest/schedules/list.html
@@ -2,10 +2,134 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET schedules</h1><p>List existing on-call schedules.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the result, showing only the schedules whose name matches the query.
-</td></tr><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user making the request. This will be used to generate the calendar private urls. This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;schedules&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PWEVPB6&quot;,&#x000A;      &quot;name&quot;: &quot;Primary&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;today&quot;: &quot;2013-03-26&quot;,&#x000A;      &quot;escalation_policies&quot;: [&#x000A;&#x000A;      ]&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PT57OLG&quot;,&#x000A;      &quot;name&quot;: &quot;Secondary&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;today&quot;: &quot;2013-03-26&quot;,&#x000A;      &quot;escalation_policies&quot;: [&#x000A;&#x000A;      ]&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 100,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 2&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET schedules
+  </h1>
+  <p>
+    List existing on-call schedules.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the schedules whose name matches the query.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user making the request. This will be used to generate the calendar private urls. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "schedules": [
+    {
+      "id": "PWEVPB6",
+      "name": "Primary",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "today": "2013-03-26",
+      "escalation_policies": [
+
+      ]
+    },
+    {
+      "id": "PT57OLG",
+      "name": "Secondary",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "today": "2013-03-26",
+      "escalation_policies": [
+
+      ]
+    }
+  ],
+  "limit": 100,
+  "offset": 0,
+  "total": 2
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/overrides/create.html
+++ b/source/documentation/rest/schedules/overrides/create.html
@@ -2,23 +2,207 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules/overrides">Overrides</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules/overrides">Overrides</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST schedules/:schedule_id/overrides</h1><p>
-Create an override for a specific user covering the specified time range.
-If you create an override on top of an existing one, the last created override will have priority.
-</p>
-<p>
-You cannot create overrides in the past.
-</p>
-<p>
-If no time zone information is present in the since and until parameters, the schedule's time zone will be used.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start date and time for the override.
-</td></tr><tr><td>end</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end date and time for the override.
-</td></tr><tr><td>user_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The ID of the user who will be on call for the duration of the override.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"override":{"user_id":"<span class='curl_params-user_id contenteditable' contenteditable='true'>PHLG109</span>","start":"<span class='curl_params-start contenteditable' contenteditable='true'>2012-07-01</span>","end":"<span class='curl_params-end contenteditable' contenteditable='true'>2012-07-02</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;override&quot;: {&#x000A;    &quot;end&quot;: &quot;2012-07-02T00:00:00-04:00&quot;,&#x000A;    &quot;user&quot;: {&#x000A;      &quot;name&quot;: &quot;Aurelio Rice&quot;,&#x000A;      &quot;email&quot;: &quot;aurelio.rice@acme.com&quot;,&#x000A;      &quot;color&quot;: &quot;turquoise&quot;,&#x000A;      &quot;id&quot;: &quot;PHLG109&quot;&#x000A;    },&#x000A;    &quot;id&quot;: &quot;PQ47DCP&quot;,&#x000A;    &quot;start&quot;: &quot;2012-07-01T00:00:00-04:00&quot;&#x000A;  }&#x000A;}</code></pre></div>
-<div class="errors well"><h4>Errors</h4><div class="table-container"><table class="table table-striped"><thead><th>Code</th><th>Message</th></thead><tbody><tr><td>4001</td><td>Missing or invalid 'time' parameter</td></tr><tr><td>4002</td><td>Missing 'override' parameter</td></tr><tr><td>4003</td><td>User Not Found</td></tr><tr><td>4004</td><td>Invalid Override</td></tr><tr><td>4005</td><td>Cannot Destroy Override</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    POST schedules/:schedule_id/overrides
+  </h1>
+  <p>
+    Create an override for a specific user covering the specified time range. If you create an override on top of an existing one, the last created override will have priority.
+  </p>
+  <p>
+    You cannot create overrides in the past.
+  </p>
+  <p>
+    If no time zone information is present in the since and until parameters, the schedule's time zone will be used.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start date and time for the override.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The end date and time for the override.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            user_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The ID of the user who will be on call for the duration of the override.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"override":{"user_id":"<span class='curl_params-user_id contenteditable' contenteditable='true'>PHLG109</span>","start":"<span class='curl_params-start contenteditable' contenteditable='true'>2012-07-01</span>","end":"<span class='curl_params-end contenteditable' contenteditable='true'>2012-07-02</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "override": {
+    "end": "2012-07-02T00:00:00-04:00",
+    "user": {
+      "name": "Aurelio Rice",
+      "email": "aurelio.rice@acme.com",
+      "color": "turquoise",
+      "id": "PHLG109"
+    },
+    "id": "PQ47DCP",
+    "start": "2012-07-01T00:00:00-04:00"
+  }
+}</code>
+</pre>
+  </div>
+  <div class="errors well">
+    <h4>
+      Errors
+    </h4>
+    <div class="table-container">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>
+              Code
+            </th>
+            <th>
+              Message
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              4001
+            </td>
+            <td>
+              Missing or invalid 'time' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4002
+            </td>
+            <td>
+              Missing 'override' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4003
+            </td>
+            <td>
+              User Not Found
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4004
+            </td>
+            <td>
+              Invalid Override
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4005
+            </td>
+            <td>
+              Cannot Destroy Override
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/overrides/delete.html
+++ b/source/documentation/rest/schedules/overrides/delete.html
@@ -2,18 +2,123 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules/overrides">Overrides</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules/overrides">Overrides</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE schedules/:schedule_id/overrides/:id</h1><p>
-Remove an override. You cannot remove a past override. If the override start time is before the current time,
-but the end time is after the current time, the override will be truncated to the current time.
-If the override is truncated, the status code will be <code>200 OK</code>,
-as opposed to a <code>204 No Content</code>
-for a successful delete.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><p>None</p>
-<h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PP1565R</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
-<div class="errors well"><h4>Errors</h4><div class="table-container"><table class="table table-striped"><thead><th>Code</th><th>Message</th></thead><tbody><tr><td>4001</td><td>Missing or invalid 'time' parameter</td></tr><tr><td>4002</td><td>Missing 'override' parameter</td></tr><tr><td>4003</td><td>User Not Found</td></tr><tr><td>4004</td><td>Invalid Override</td></tr><tr><td>4005</td><td>Cannot Destroy Override</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    DELETE schedules/:schedule_id/overrides/:id
+  </h1>
+  <p>
+    Remove an override. You cannot remove a past override. If the override start time is before the current time, but the end time is after the current time, the override will be truncated to the current time. If the override is truncated, the status code will be <code>200 OK</code>, as opposed to a <code>204 No Content</code> for a successful delete.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <p>
+    None
+  </p>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PP1565R</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
+  <div class="errors well">
+    <h4>
+      Errors
+    </h4>
+    <div class="table-container">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>
+              Code
+            </th>
+            <th>
+              Message
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              4001
+            </td>
+            <td>
+              Missing or invalid 'time' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4002
+            </td>
+            <td>
+              Missing 'override' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4003
+            </td>
+            <td>
+              User Not Found
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4004
+            </td>
+            <td>
+              Invalid Override
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4005
+            </td>
+            <td>
+              Cannot Destroy Override
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/overrides/index.html
+++ b/source/documentation/rest/schedules/overrides/index.html
@@ -2,9 +2,65 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Overrides</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Overrides
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Schedule Overrides API</h1>
-<table class="table action_index"><caption>Schedule overrides are custom, non-recurring exceptions to your regular on-call schedules. Use them when your team members go on vacation, swap shifts, or when you simply cannot achieve your normal scheduling with recurring layers.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/schedules/overrides/list">GET schedules/:schedule_id/overrides</a></td><td>List overrides for a given time range.</td></tr><tr><td><a href="/documentation/rest/schedules/overrides/create">POST schedules/:schedule_id/overrides</a></td><td>Create an override for a specific user covering the specified time range.</td></tr><tr><td><a href="/documentation/rest/schedules/overrides/delete">DELETE schedules/:schedule_id/overrides/:id</a></td><td>Remove an override.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Schedule Overrides API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      Schedule overrides are custom, non-recurring exceptions to your regular on-call schedules. Use them when your team members go on vacation, swap shifts, or when you simply cannot achieve your normal scheduling with recurring layers.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/overrides/list">GET schedules/:schedule_id/overrides</a>
+        </td>
+        <td>
+          List overrides for a given time range.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/overrides/create">POST schedules/:schedule_id/overrides</a>
+        </td>
+        <td>
+          Create an override for a specific user covering the specified time range.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/schedules/overrides/delete">DELETE schedules/:schedule_id/overrides/:id</a>
+        </td>
+        <td>
+          Remove an override.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/schedules/overrides/list.html
+++ b/source/documentation/rest/schedules/overrides/list.html
@@ -2,41 +2,267 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules/overrides">Overrides</a></li><span class="divider">/</span><li>List</li></ul>
-<div class='section'>
-<h1 class="title">GET schedules/:schedule_id/overrides</h1><p>List overrides for a given time range.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td><p>The start time of the date range you want to retrieve override for.</p>
-<p>The maximum date range queryable is 3 months.</p>
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The end time of the date range you want to retrieve override for.
-</td></tr><tr><td>editable</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>When this parameter is present, only editable overrides will be returned.
-The result will only include the id the override if this parameter is present.
-Only future overrides are editable.
-</td></tr><tr><td>overflow</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td><p>
-Any on-call schedule entries that pass the date range bounds will be truncated at the
-bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
-</p>
-<p>
-For instance, if your schedule is a rotation that changes daily at midnight UTC, and
-your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
-</p>
-<ul>
-<li>
-If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code>
-of <code>2011-06-01T14:00:00Z</code>.
-</li>
-<li>
-If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code>
-of <code>2011-06-02T00:00:00Z</code>.
-</li>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules/overrides">Overrides</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
 </ul>
-</td></tr>
-</tbody></table></div><h3>Example 1:</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;overrides&quot;: [&#x000A;    {&#x000A;      &quot;end&quot;: &quot;2012-06-16T13:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-06-15T16:20:38-04:00&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;color&quot;: &quot;turquoise&quot;,&#x000A;        &quot;name&quot;: &quot;Aurelio Rice&quot;,&#x000A;        &quot;email&quot;: &quot;aurelio.rice@acme.com&quot;,&#x000A;        &quot;id&quot;: &quot;PHLG109&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
-<h3>Example 2: Editable overrides (include their ids)</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \&#x000A;    --data-urlencode "editable=true" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;overrides&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PQ47DCP&quot;,&#x000A;      &quot;end&quot;: &quot;2012-06-16T13:00:00-04:00&quot;,&#x000A;      &quot;start&quot;: &quot;2012-06-15T16:20:38-04:00&quot;,&#x000A;      &quot;user&quot;: {&#x000A;        &quot;color&quot;: &quot;turquoise&quot;,&#x000A;        &quot;name&quot;: &quot;Aurelio Rice&quot;,&#x000A;        &quot;email&quot;: &quot;aurelio.rice@acme.com&quot;,&#x000A;        &quot;id&quot;: &quot;PHLG109&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
-<div class="errors well"><h4>Errors</h4><div class="table-container"><table class="table table-striped"><thead><th>Code</th><th>Message</th></thead><tbody><tr><td>4001</td><td>Missing or invalid 'time' parameter</td></tr><tr><td>4002</td><td>Missing 'override' parameter</td></tr><tr><td>4003</td><td>User Not Found</td></tr><tr><td>4004</td><td>Invalid Override</td></tr><tr><td>4005</td><td>Cannot Destroy Override</td></tr></tbody></table></div></div>
+<div class='section'>
+  <h1 class="title">
+    GET schedules/:schedule_id/overrides
+  </h1>
+  <p>
+    List overrides for a given time range.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:schedule_id</span>/overrides
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            <p>
+              The start time of the date range you want to retrieve override for.
+            </p>
+            <p>
+              The maximum date range queryable is 3 months.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The end time of the date range you want to retrieve override for.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            editable
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            When this parameter is present, only editable overrides will be returned. The result will only include the id the override if this parameter is present. Only future overrides are editable.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            overflow
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
+            </p>
+            <p>
+              For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
+            </p>
+            <ul>
+              <li>If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code> of <code>2011-06-01T14:00:00Z</code>.
+              </li>
+              <li>If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code> of <code>2011-06-02T00:00:00Z</code>.
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example 1:
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "overrides": [
+    {
+      "end": "2012-06-16T13:00:00-04:00",
+      "start": "2012-06-15T16:20:38-04:00",
+      "user": {
+        "color": "turquoise",
+        "name": "Aurelio Rice",
+        "email": "aurelio.rice@acme.com",
+        "id": "PHLG109"
+      }
+    }
+  ],
+  "total": 1
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example 2: Editable overrides (include their ids)
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-06-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \
+    --data-urlencode "editable=true" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-schedule_id schedule_id contenteditable" contenteditable="true">PIJ90N7</span>/overrides"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "overrides": [
+    {
+      "id": "PQ47DCP",
+      "end": "2012-06-16T13:00:00-04:00",
+      "start": "2012-06-15T16:20:38-04:00",
+      "user": {
+        "color": "turquoise",
+        "name": "Aurelio Rice",
+        "email": "aurelio.rice@acme.com",
+        "id": "PHLG109"
+      }
+    }
+  ],
+  "total": 1
+}</code>
+</pre>
+  </div>
+  <div class="errors well">
+    <h4>
+      Errors
+    </h4>
+    <div class="table-container">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>
+              Code
+            </th>
+            <th>
+              Message
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              4001
+            </td>
+            <td>
+              Missing or invalid 'time' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4002
+            </td>
+            <td>
+              Missing 'override' parameter
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4003
+            </td>
+            <td>
+              User Not Found
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4004
+            </td>
+            <td>
+              Invalid Override
+            </td>
+          </tr>
+          <tr>
+            <td>
+              4005
+            </td>
+            <td>
+              Cannot Destroy Override
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/preview.html
+++ b/source/documentation/rest/schedules/preview.html
@@ -2,60 +2,644 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Preview</li></ul>
-<div class='section'>
-<h1 class="title">POST schedules/preview</h1><p>
-Preview what a schedule would look like without saving it. This work the same as the
-<a href="/documentation/rest/schedules/update">update</a> or <a href="/documentation/rest/schedules/create">create</a> actions, except that
-the result is not persisted. Preview optionally takes two additional
-arguments, <code>since</code> and <code>until</code>, deliminating the span of the preview.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/preview</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The start of the date range over which you want to return on-call schedule entries and on-call schedule layers.
-If not specified, <code>since</code> defaults to the current time
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end of the date range over which you want to return schedule entries and on-call schedule layers.
-If not specificed, <code>until</code> defaults to one week from the current time.
-</td></tr><tr><td>overflow</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td><p>
-Any on-call schedule entries that pass the date range bounds will be truncated at the
-bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
-</p>
-<p>
-For instance, if your schedule is a rotation that changes daily at midnight UTC, and
-your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
-</p>
-<ul>
-<li>
-If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code>
-of <code>2011-06-01T14:00:00Z</code>.
-</li>
-<li>
-If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code>
-of <code>2011-06-02T00:00:00Z</code>.
-</li>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Preview
+  </li>
 </ul>
-</td></tr>
-<tr><td>schedule</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>The schedule object. See schedule parameters for details.
-</td></tr></tbody></table></div><h3>Schedule Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>schedule_layers</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>A list of schedule layers. See the schedule layers parameters for details.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>Yes</td><td>The time zone of the schedule.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the schedule
-</td></tr></tbody></table></div><h3>Schedule Layer Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The unique identifier of the schedule layer. Include this if previewing an update to a layer that already exists. Omit this parameter when previewing a layer that doesn't yet exist.
-</td></tr><tr><td>start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start time of this layer.
-</td></tr><tr><td>end</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end time of this layer. If null, the layer does not end.
-</td></tr><tr><td>users</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td><p>
-The ordered list of users on this layer. Use the member order to indicate their order.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;P2BI1SS&quot;&#x000A;      },&#x000A;      &quot;member_order&quot;: 1&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>restriction_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Can either be <code>Daily</code> or <code>Weekly</code>. Specify the types of <code>restriction</code>.
-</td></tr><tr><td>restrictions</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td><p>
-An array of restrictions for the layer. A restriction is a limit on which period of the
-day or week the schedule layer can accept events.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;restrictions&quot;: [&#x000A;    {&#x000A;      &quot;duration_seconds&quot;: 43200,&#x000A;      &quot;start_time_of_day&quot;: &quot;00:00:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>rotation_virtual_start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The effective start time of the layer. This can be before the start time of the schedule.
-</td></tr><tr><td>priority</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The priority of the layer. Layers with higher priority will override layers with a lower priority.
-</td></tr><tr><td>rotation_turn_length_seconds</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The duration of each on-call shift in seconds.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the schedule layer.
-</td></tr></tbody></table></div>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "schedule": {&#x000A;        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Tertiary</span>",&#x000A;        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>Eastern Time (US &amp; Canada)</span>",&#x000A;        "schedule_layers": [&#x000A;          {&#x000A;            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",&#x000A;            "priority": 0,&#x000A;            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",&#x000A;            "rotation_turn_length_seconds": 604800,&#x000A;            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",&#x000A;            "users": [&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"&#x000A;                },&#x000A;                "member_order": 1&#x000A;              },&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PRDFNAL</span>"&#x000A;                },&#x000A;                "member_order": 2&#x000A;              }&#x000A;            ],&#x000A;            "end": null,&#x000A;            "restrictions": [&#x000A;              {&#x000A;                "duration_seconds": 43200,&#x000A;                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"&#x000A;              }&#x000A;            ],&#x000A;            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>"&#x000A;          },&#x000A;          {&#x000A;            "restriction_type": null,&#x000A;            "priority": 1,&#x000A;            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",&#x000A;            "rotation_turn_length_seconds": 604800,&#x000A;            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",&#x000A;            "users": [&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PT23IWX</span>"&#x000A;                },&#x000A;                "member_order": 1&#x000A;              }&#x000A;            ],&#x000A;            "end": null,&#x000A;            "restrictions": [&#x000A;    &#x000A;            ],&#x000A;            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 2</span>"&#x000A;          }&#x000A;        ]&#x000A;      }&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/preview"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;schedule&quot;: {&#x000A;    &quot;id&quot;: null,&#x000A;    &quot;name&quot;: &quot;Tertiary&quot;,&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;today&quot;: &quot;2013-03-26&quot;,&#x000A;    &quot;escalation_policies&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;schedule_layers&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Schedule Layer 1&quot;,&#x000A;        &quot;rendered_schedule_entries&quot;: [&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-27T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-03-27T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-28T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-03-28T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-29T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-03-29T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-30T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-03-30T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-31T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-03-31T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PRDFNAL&quot;,&#x000A;              &quot;name&quot;: &quot;Sarah Jones&quot;,&#x000A;              &quot;email&quot;: &quot;sarah@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;green&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-04-01T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-04-01T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PRDFNAL&quot;,&#x000A;              &quot;name&quot;: &quot;Sarah Jones&quot;,&#x000A;              &quot;email&quot;: &quot;sarah@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;green&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          },&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-04-02T00:00:00-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-04-02T12:00:00-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PRDFNAL&quot;,&#x000A;              &quot;name&quot;: &quot;Sarah Jones&quot;,&#x000A;              &quot;email&quot;: &quot;sarah@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;green&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          }&#x000A;        ],&#x000A;        &quot;id&quot;: null,&#x000A;        &quot;priority&quot;: 0,&#x000A;        &quot;start&quot;: &quot;2013-03-26T20:42:15-04:00&quot;,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;restriction_type&quot;: &quot;Daily&quot;,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2012-01-01T00:00:00-05:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 604800,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;member_order&quot;: 1,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            }&#x000A;          },&#x000A;          {&#x000A;            &quot;member_order&quot;: 2,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PRDFNAL&quot;,&#x000A;              &quot;name&quot;: &quot;Sarah Jones&quot;,&#x000A;              &quot;email&quot;: &quot;sarah@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;green&quot;&#x000A;            }&#x000A;          }&#x000A;        ],&#x000A;        &quot;restrictions&quot;: [&#x000A;          {&#x000A;            &quot;start_time_of_day&quot;: &quot;00:00:00&quot;,&#x000A;            &quot;duration_seconds&quot;: 43200&#x000A;          }&#x000A;        ],&#x000A;        &quot;rendered_coverage_percentage&quot;: 55.2&#x000A;      },&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Schedule Layer 2&quot;,&#x000A;        &quot;rendered_schedule_entries&quot;: [&#x000A;          {&#x000A;            &quot;start&quot;: &quot;2013-03-26T20:42:16-04:00&quot;,&#x000A;            &quot;end&quot;: &quot;2013-04-02T20:42:16-04:00&quot;,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;              &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;              &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;purple&quot;&#x000A;            },&#x000A;            &quot;id&quot;: null&#x000A;          }&#x000A;        ],&#x000A;        &quot;id&quot;: null,&#x000A;        &quot;priority&quot;: 1,&#x000A;        &quot;start&quot;: &quot;2013-03-26T20:42:15-04:00&quot;,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;restriction_type&quot;: null,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2012-01-01T00:00:00-05:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 604800,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;member_order&quot;: 1,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;              &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;              &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;purple&quot;&#x000A;            }&#x000A;          }&#x000A;        ],&#x000A;        &quot;restrictions&quot;: [&#x000A;&#x000A;        ],&#x000A;        &quot;rendered_coverage_percentage&quot;: 100.0&#x000A;      }&#x000A;    ],&#x000A;    &quot;final_schedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Final Schedule&quot;,&#x000A;      &quot;rendered_schedule_entries&quot;: [&#x000A;        {&#x000A;          &quot;start&quot;: &quot;2013-03-26T20:42:16-04:00&quot;,&#x000A;          &quot;end&quot;: &quot;2013-04-02T20:42:16-04:00&quot;,&#x000A;          &quot;user&quot;: {&#x000A;            &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;            &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;            &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;            &quot;color&quot;: &quot;purple&quot;&#x000A;          },&#x000A;          &quot;id&quot;: null&#x000A;        }&#x000A;      ],&#x000A;      &quot;rendered_coverage_percentage&quot;: 100.0&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+<div class='section'>
+  <h1 class="title">
+    POST schedules/preview
+  </h1>
+  <p>
+    Preview what a schedule would look like without saving it. This work the same as the <a href="/documentation/rest/schedules/update">update</a> or <a href="/documentation/rest/schedules/create">create</a> actions, except that the result is not persisted. Preview optionally takes two additional arguments, <code>since</code> and <code>until</code>, deliminating the span of the preview.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/preview
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to return on-call schedule entries and on-call schedule layers. If not specified, <code>since</code> defaults to the current time
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end of the date range over which you want to return schedule entries and on-call schedule layers. If not specificed, <code>until</code> defaults to one week from the current time.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            overflow
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
+            </p>
+            <p>
+              For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
+            </p>
+            <ul>
+              <li>If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code> of <code>2011-06-01T14:00:00Z</code>.
+              </li>
+              <li>If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code> of <code>2011-06-02T00:00:00Z</code>.
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            schedule
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The schedule object. See schedule parameters for details.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Schedule Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            schedule_layers
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A list of schedule layers. See the schedule layers parameters for details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The time zone of the schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the schedule
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Schedule Layer Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The unique identifier of the schedule layer. Include this if previewing an update to a layer that already exists. Omit this parameter when previewing a layer that doesn't yet exist.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start time of this layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end time of this layer. If null, the layer does not end.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            users
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            <p>
+              The ordered list of users on this layer. Use the member order to indicate their order.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "user": {
+        "id": "P2BI1SS"
+      },
+      "member_order": 1
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restriction_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Can either be <code>Daily</code> or <code>Weekly</code>. Specify the types of <code>restriction</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restrictions
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              An array of restrictions for the layer. A restriction is a limit on which period of the day or week the schedule layer can accept events.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "restrictions": [
+    {
+      "duration_seconds": 43200,
+      "start_time_of_day": "00:00:00"
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_virtual_start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The effective start time of the layer. This can be before the start time of the schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            priority
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The priority of the layer. Layers with higher priority will override layers with a lower priority.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_turn_length_seconds
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The duration of each on-call shift in seconds.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the schedule layer.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "schedule": {
+        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Tertiary</span>",
+        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>Eastern Time (US &amp; Canada)</span>",
+        "schedule_layers": [
+          {
+            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",
+            "priority": 0,
+            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",
+            "rotation_turn_length_seconds": 604800,
+            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",
+            "users": [
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPSFHH7</span>"
+                },
+                "member_order": 1
+              },
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PRDFNAL</span>"
+                },
+                "member_order": 2
+              }
+            ],
+            "end": null,
+            "restrictions": [
+              {
+                "duration_seconds": 43200,
+                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"
+              }
+            ],
+            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>"
+          },
+          {
+            "restriction_type": null,
+            "priority": 1,
+            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",
+            "rotation_turn_length_seconds": 604800,
+            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-01-01T00:00:00</span>",
+            "users": [
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PT23IWX</span>"
+                },
+                "member_order": 1
+              }
+            ],
+            "end": null,
+            "restrictions": [
+    
+            ],
+            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 2</span>"
+          }
+        ]
+      }
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/preview"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "schedule": {
+    "id": null,
+    "name": "Tertiary",
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "today": "2013-03-26",
+    "escalation_policies": [
+
+    ],
+    "schedule_layers": [
+      {
+        "name": "Schedule Layer 1",
+        "rendered_schedule_entries": [
+          {
+            "start": "2013-03-27T00:00:00-04:00",
+            "end": "2013-03-27T12:00:00-04:00",
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-03-28T00:00:00-04:00",
+            "end": "2013-03-28T12:00:00-04:00",
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-03-29T00:00:00-04:00",
+            "end": "2013-03-29T12:00:00-04:00",
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-03-30T00:00:00-04:00",
+            "end": "2013-03-30T12:00:00-04:00",
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-03-31T00:00:00-04:00",
+            "end": "2013-03-31T12:00:00-04:00",
+            "user": {
+              "id": "PRDFNAL",
+              "name": "Sarah Jones",
+              "email": "sarah@acme.com",
+              "color": "green"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-04-01T00:00:00-04:00",
+            "end": "2013-04-01T12:00:00-04:00",
+            "user": {
+              "id": "PRDFNAL",
+              "name": "Sarah Jones",
+              "email": "sarah@acme.com",
+              "color": "green"
+            },
+            "id": null
+          },
+          {
+            "start": "2013-04-02T00:00:00-04:00",
+            "end": "2013-04-02T12:00:00-04:00",
+            "user": {
+              "id": "PRDFNAL",
+              "name": "Sarah Jones",
+              "email": "sarah@acme.com",
+              "color": "green"
+            },
+            "id": null
+          }
+        ],
+        "id": null,
+        "priority": 0,
+        "start": "2013-03-26T20:42:15-04:00",
+        "end": null,
+        "restriction_type": "Daily",
+        "rotation_virtual_start": "2012-01-01T00:00:00-05:00",
+        "rotation_turn_length_seconds": 604800,
+        "users": [
+          {
+            "member_order": 1,
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            }
+          },
+          {
+            "member_order": 2,
+            "user": {
+              "id": "PRDFNAL",
+              "name": "Sarah Jones",
+              "email": "sarah@acme.com",
+              "color": "green"
+            }
+          }
+        ],
+        "restrictions": [
+          {
+            "start_time_of_day": "00:00:00",
+            "duration_seconds": 43200
+          }
+        ],
+        "rendered_coverage_percentage": 55.2
+      },
+      {
+        "name": "Schedule Layer 2",
+        "rendered_schedule_entries": [
+          {
+            "start": "2013-03-26T20:42:16-04:00",
+            "end": "2013-04-02T20:42:16-04:00",
+            "user": {
+              "id": "PT23IWX",
+              "name": "Tim Wright",
+              "email": "tim@acme.com",
+              "color": "purple"
+            },
+            "id": null
+          }
+        ],
+        "id": null,
+        "priority": 1,
+        "start": "2013-03-26T20:42:15-04:00",
+        "end": null,
+        "restriction_type": null,
+        "rotation_virtual_start": "2012-01-01T00:00:00-05:00",
+        "rotation_turn_length_seconds": 604800,
+        "users": [
+          {
+            "member_order": 1,
+            "user": {
+              "id": "PT23IWX",
+              "name": "Tim Wright",
+              "email": "tim@acme.com",
+              "color": "purple"
+            }
+          }
+        ],
+        "restrictions": [
+
+        ],
+        "rendered_coverage_percentage": 100.0
+      }
+    ],
+    "final_schedule": {
+      "name": "Final Schedule",
+      "rendered_schedule_entries": [
+        {
+          "start": "2013-03-26T20:42:16-04:00",
+          "end": "2013-04-02T20:42:16-04:00",
+          "user": {
+            "id": "PT23IWX",
+            "name": "Tim Wright",
+            "email": "tim@acme.com",
+            "color": "purple"
+          },
+          "id": null
+        }
+      ],
+      "rendered_coverage_percentage": 100.0
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/show.html
+++ b/source/documentation/rest/schedules/show.html
@@ -2,34 +2,465 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET schedules/:id</h1><p>Show detailed information about a schedule, including entries for each layer and sub-schedule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td><p>The start of the date range over which you want to return on-call schedule entries and on-call schedule layers.</p>
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end of the date range over which you want to return schedule entries and on-call schedule layers.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to account time zone.
-</td></tr></tbody></table></div><h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>schedule_layers</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of schedule layers.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the schedule
-</td></tr><tr><td>final_schedule</td><td><a href="/documentation/rest/types#object">Object</a></td><td>The final schedule layer object.
-</td></tr><tr><td>overrides_subschedule</td><td><a href="/documentation/rest/types#object">Object</a></td><td>The schedule layer object where all the overrides are stored.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>The time zone of the schedule.
-</td></tr><tr><td>escalation_policies</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An array of all the escalation policies that uses this schedule.
-</td></tr><tr><td>today</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The current day in the schedule's time zone.
-</td></tr></tbody></table></div><h2>The Schedule Layer Object</h2>
-<p>A schedule is composed of multiple schedule layers.</p>
-<p>A layer is composed of a group of people who will rotate through the same shift. In a basic weekly schedule, you create a single layer where each member is on-call for one week, with a set day and time for transferring on-call duty.</p>
-<p>When a schedule has multiple layers, the layer can be ordered using the priority field. The layer with the highest priority has precedence over the layers with lower priority. You can use restrictions to control how layers overlap.</p>
-<p>The override layer is a special layer where all the override entries are stored.</p>
-<p>The final layer is a special layer that contains the result of all the previous layers put together. This layer cannot be edited.</p>
-<h3>Schedule Layer Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>rendered_schedule_entries</td><td><a href="/documentation/rest/types#array">Array</a></td><td>This is a list of entries to be rendered for the current time range.
-</td></tr><tr><td>restriction_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Possible values are <code>daily</code> or <code>weekly</code>. This specifies the type of restrictions present on this layer.
-</td></tr><tr><td>restrictions</td><td><a href="/documentation/rest/types#array">Array</a></td><td>A list of time restrictions for this layer.
-</td></tr><tr><td>priority</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The priority of the layer. Layers with higher priority will override layers with a lower priority.
-</td></tr><tr><td>start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The effective start date of the layer
-</td></tr><tr><td>end</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The effective end date of the layer. If missing or null, the layer has no end date.
-</td></tr><tr><td>rendered_coverage_percentage</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The percentage of the time range covered by this layer.
-</td></tr><tr><td>rotation_turn_length_seconds</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>The duration of each on-call shift in seconds.
-</td></tr><tr><td>rotation_virtual_start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The effective start time of the layer. This can be before the start time of the schedule.
-</td></tr><tr><td>users</td><td><a href="/documentation/rest/types#array">Array</a></td><td>An ordered list of users in this layer. The member_order field controls the order in which the users apear in the rotation.
-</td></tr></tbody></table></div>
-<h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PWEVPB6</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;schedule&quot;: {&#x000A;    &quot;id&quot;: &quot;PWEVPB6&quot;,&#x000A;    &quot;name&quot;: &quot;Primary&quot;,&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;today&quot;: &quot;2013-03-26&quot;,&#x000A;    &quot;escalation_policies&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;schedule_layers&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Schedule Layer 2&quot;,&#x000A;        &quot;rendered_schedule_entries&quot;: [&#x000A;&#x000A;        ],&#x000A;        &quot;id&quot;: &quot;POM1B2S&quot;,&#x000A;        &quot;priority&quot;: 1,&#x000A;        &quot;start&quot;: &quot;2013-02-25T18:38:44-05:00&quot;,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;restriction_type&quot;: &quot;Daily&quot;,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2013-02-24T00:00:00-05:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 86400,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;member_order&quot;: 1,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PPSFHH7&quot;,&#x000A;              &quot;name&quot;: &quot;Bob Smith&quot;,&#x000A;              &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;red&quot;&#x000A;            }&#x000A;          },&#x000A;          {&#x000A;            &quot;member_order&quot;: 2,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PRDFNAL&quot;,&#x000A;              &quot;name&quot;: &quot;Sarah Jones&quot;,&#x000A;              &quot;email&quot;: &quot;sarah@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;green&quot;&#x000A;            }&#x000A;          }&#x000A;        ],&#x000A;        &quot;restrictions&quot;: [&#x000A;          {&#x000A;            &quot;start_time_of_day&quot;: &quot;00:00:00&quot;,&#x000A;            &quot;duration_seconds&quot;: 43200&#x000A;          }&#x000A;        ],&#x000A;        &quot;rendered_coverage_percentage&quot;: 0.0&#x000A;      },&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Schedule Layer 1&quot;,&#x000A;        &quot;rendered_schedule_entries&quot;: [&#x000A;&#x000A;        ],&#x000A;        &quot;id&quot;: &quot;PSYPBEF&quot;,&#x000A;        &quot;priority&quot;: 0,&#x000A;        &quot;start&quot;: &quot;2013-02-25T18:38:44-05:00&quot;,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;restriction_type&quot;: null,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2013-02-24T00:00:00-05:00&quot;,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 86400,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;member_order&quot;: 1,&#x000A;            &quot;user&quot;: {&#x000A;              &quot;id&quot;: &quot;PT23IWX&quot;,&#x000A;              &quot;name&quot;: &quot;Tim Wright&quot;,&#x000A;              &quot;email&quot;: &quot;tim@acme.com&quot;,&#x000A;              &quot;color&quot;: &quot;purple&quot;&#x000A;            }&#x000A;          }&#x000A;        ],&#x000A;        &quot;restrictions&quot;: [&#x000A;&#x000A;        ],&#x000A;        &quot;rendered_coverage_percentage&quot;: 0.0&#x000A;      }&#x000A;    ],&#x000A;    &quot;overrides_subschedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Overrides&quot;,&#x000A;      &quot;rendered_schedule_entries&quot;: [&#x000A;&#x000A;      ]&#x000A;    },&#x000A;    &quot;final_schedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Final Schedule&quot;,&#x000A;      &quot;rendered_schedule_entries&quot;: [&#x000A;&#x000A;      ],&#x000A;      &quot;rendered_coverage_percentage&quot;: 0.0&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET schedules/:id
+  </h1>
+  <p>
+    Show detailed information about a schedule, including entries for each layer and sub-schedule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The start of the date range over which you want to return on-call schedule entries and on-call schedule layers.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end of the date range over which you want to return schedule entries and on-call schedule layers.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to account time zone.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            schedule_layers
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of schedule layers.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the schedule
+          </td>
+        </tr>
+        <tr>
+          <td>
+            final_schedule
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            The final schedule layer object.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            overrides_subschedule
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            The schedule layer object where all the overrides are stored.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            The time zone of the schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policies
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An array of all the escalation policies that uses this schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            today
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The current day in the schedule's time zone.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    The Schedule Layer Object
+  </h2>
+  <p>
+    A schedule is composed of multiple schedule layers.
+  </p>
+  <p>
+    A layer is composed of a group of people who will rotate through the same shift. In a basic weekly schedule, you create a single layer where each member is on-call for one week, with a set day and time for transferring on-call duty.
+  </p>
+  <p>
+    When a schedule has multiple layers, the layer can be ordered using the priority field. The layer with the highest priority has precedence over the layers with lower priority. You can use restrictions to control how layers overlap.
+  </p>
+  <p>
+    The override layer is a special layer where all the override entries are stored.
+  </p>
+  <p>
+    The final layer is a special layer that contains the result of all the previous layers put together. This layer cannot be edited.
+  </p>
+  <h3>
+    Schedule Layer Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            rendered_schedule_entries
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            This is a list of entries to be rendered for the current time range.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restriction_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Possible values are <code>daily</code> or <code>weekly</code>. This specifies the type of restrictions present on this layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restrictions
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            A list of time restrictions for this layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            priority
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The priority of the layer. Layers with higher priority will override layers with a lower priority.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The effective start date of the layer
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The effective end date of the layer. If missing or null, the layer has no end date.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rendered_coverage_percentage
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The percentage of the time range covered by this layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_turn_length_seconds
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            The duration of each on-call shift in seconds.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_virtual_start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The effective start time of the layer. This can be before the start time of the schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            users
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            An ordered list of users in this layer. The member_order field controls the order in which the users apear in the rotation.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PWEVPB6</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "schedule": {
+    "id": "PWEVPB6",
+    "name": "Primary",
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "today": "2013-03-26",
+    "escalation_policies": [
+
+    ],
+    "schedule_layers": [
+      {
+        "name": "Schedule Layer 2",
+        "rendered_schedule_entries": [
+
+        ],
+        "id": "POM1B2S",
+        "priority": 1,
+        "start": "2013-02-25T18:38:44-05:00",
+        "end": null,
+        "restriction_type": "Daily",
+        "rotation_virtual_start": "2013-02-24T00:00:00-05:00",
+        "rotation_turn_length_seconds": 86400,
+        "users": [
+          {
+            "member_order": 1,
+            "user": {
+              "id": "PPSFHH7",
+              "name": "Bob Smith",
+              "email": "bob@acme.com",
+              "color": "red"
+            }
+          },
+          {
+            "member_order": 2,
+            "user": {
+              "id": "PRDFNAL",
+              "name": "Sarah Jones",
+              "email": "sarah@acme.com",
+              "color": "green"
+            }
+          }
+        ],
+        "restrictions": [
+          {
+            "start_time_of_day": "00:00:00",
+            "duration_seconds": 43200
+          }
+        ],
+        "rendered_coverage_percentage": 0.0
+      },
+      {
+        "name": "Schedule Layer 1",
+        "rendered_schedule_entries": [
+
+        ],
+        "id": "PSYPBEF",
+        "priority": 0,
+        "start": "2013-02-25T18:38:44-05:00",
+        "end": null,
+        "restriction_type": null,
+        "rotation_virtual_start": "2013-02-24T00:00:00-05:00",
+        "rotation_turn_length_seconds": 86400,
+        "users": [
+          {
+            "member_order": 1,
+            "user": {
+              "id": "PT23IWX",
+              "name": "Tim Wright",
+              "email": "tim@acme.com",
+              "color": "purple"
+            }
+          }
+        ],
+        "restrictions": [
+
+        ],
+        "rendered_coverage_percentage": 0.0
+      }
+    ],
+    "overrides_subschedule": {
+      "name": "Overrides",
+      "rendered_schedule_entries": [
+
+      ]
+    },
+    "final_schedule": {
+      "name": "Final Schedule",
+      "rendered_schedule_entries": [
+
+      ],
+      "rendered_coverage_percentage": 0.0
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/update.html
+++ b/source/documentation/rest/schedules/update.html
@@ -2,57 +2,446 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Update</li></ul>
-<div class='section'>
-<h1 class="title">PUT schedules/:id</h1><p>Update an existing on-call schedule.</p>
-<div class='alert-info alert alert-block'>
-<h4>Note:</h4>
-You cannot delete schedule layers. You must include all layers in your update request.
-To delete a layer, set the <code>end</code> parameter to schedule its termination.
-See the "Schedule Layer Parameters" section below for more information.
-</div>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>overflow</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td><p>
-Any on-call schedule entries that pass the date range bounds will be truncated at the
-bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
-</p>
-<p>
-For instance, if your schedule is a rotation that changes daily at midnight UTC, and
-your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
-</p>
-<ul>
-<li>
-If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code>
-of <code>2011-06-01T14:00:00Z</code>.
-</li>
-<li>
-If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule
-entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code>
-of <code>2011-06-02T00:00:00Z</code>.
-</li>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
 </ul>
-</td></tr>
-<tr><td>schedule</td><td><a href="/documentation/rest/types#object">Object</a></td><td>No</td><td>The schedule object. See schedule parameters for details.
-</td></tr></tbody></table></div><h3>Schedule Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>schedule_layers</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td>A list of schedule layers. See the schedule layers parameters for details.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>Yes</td><td>The time zone of the schedule.
-</td></tr></tbody></table></div><h3>Schedule Layer Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The unique identifier of the schedule layer to update. Omit this if creating a new schedule layer.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the schedule layer.
-</td></tr><tr><td>start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The start time of this layer.
-</td></tr><tr><td>end</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end time of this layer. If null, the layer does not end.
-</td></tr><tr><td>users</td><td><a href="/documentation/rest/types#array">Array</a></td><td>Yes</td><td><p>
-The ordered list of users on this layer. Use the member order to indicate their order.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;user&quot;: {&#x000A;        &quot;id&quot;: &quot;P2BI1SS&quot;&#x000A;      },&#x000A;      &quot;member_order&quot;: 1&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>restriction_type</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Can either be <code>Daily</code> or <code>Weekly</code>. Specifies the type of <code>restriction</code>.
-</td></tr><tr><td>restrictions</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td><p>
-An array of restrictions for the layer. A restriction is a limit on which period of the
-day or week the schedule layer can accept events.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;restrictions&quot;: [&#x000A;    {&#x000A;      &quot;duration_seconds&quot;: 43200,&#x000A;      &quot;start_time_of_day&quot;: &quot;00:00:00&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre>
-</td></tr><tr><td>rotation_virtual_start</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The effective start time of the layer. This can be before the start time of the schedule.
-</td></tr><tr><td>priority</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The priority of the layer. Layers with higher priority will override layers with a lower priority.
-</td></tr><tr><td>rotation_turn_length_seconds</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>The duration of each on-call shift in seconds.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{    &#x000A;      "since": "<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;      "until": "<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-19T00:00:00</span>",&#x000A;      "overflow": 1,&#x000A;      "schedule": {&#x000A;        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>UTC</span>",&#x000A;        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>new name</span>",&#x000A;        "schedule_layers": [&#x000A;          {&#x000A;            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>",&#x000A;            "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P07F6S3</span>",&#x000A;            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",&#x000A;            "priority": 0,&#x000A;            "rotation_turn_length_seconds": 604800,&#x000A;            "users": [&#x000A;              {&#x000A;                "user": {&#x000A;                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPI9KUT</span>"&#x000A;                },&#x000A;                "member_order": 1&#x000A;              }&#x000A;            ],&#x000A;            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",&#x000A;            "restrictions": [&#x000A;              {&#x000A;                "duration_seconds": "<span class='curl_params-duration_seconds contenteditable' contenteditable='true'>43200</span>",&#x000A;                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"&#x000A;              }&#x000A;            ]&#x000A;          }&#x000A;        ]&#x000A;      }&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/:id"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;schedule&quot;: {&#x000A;    &quot;today&quot;: &quot;2012-08-24&quot;,&#x000A;    &quot;overrides_subschedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Overrides&quot;&#x000A;    },&#x000A;    &quot;final_schedule&quot;: {&#x000A;      &quot;name&quot;: &quot;Final Schedule&quot;&#x000A;    },&#x000A;    &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;    &quot;name&quot;: &quot;new name&quot;,&#x000A;    &quot;time_zone&quot;: &quot;UTC&quot;,&#x000A;    &quot;escalation_policies&quot;: [&#x000A;&#x000A;    ],&#x000A;    &quot;schedule_layers&quot;: [&#x000A;      {&#x000A;        &quot;restrictions&quot;: [&#x000A;          {&#x000A;            &quot;start_time_of_day&quot;: &quot;00:00:00&quot;,&#x000A;            &quot;duration_seconds&quot;: 43200&#x000A;          }&#x000A;        ],&#x000A;        &quot;start&quot;: &quot;2012-08-24T02:39:33Z&quot;,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;rotation_turn_length_seconds&quot;: 604800,&#x000A;        &quot;rotation_virtual_start&quot;: &quot;2012-08-05T00:00:00Z&quot;,&#x000A;        &quot;restriction_type&quot;: &quot;Daily&quot;,&#x000A;        &quot;id&quot;: &quot;P07F6S3&quot;,&#x000A;        &quot;name&quot;: &quot;Schedule Layer 1&quot;,&#x000A;        &quot;users&quot;: [&#x000A;          {&#x000A;            &quot;user&quot;: {&#x000A;              &quot;color&quot;: &quot;purple&quot;,&#x000A;              &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;              &quot;name&quot;: &quot;Alan&quot;,&#x000A;              &quot;email&quot;: &quot;alankay@example.com&quot;&#x000A;            },&#x000A;            &quot;member_order&quot;: 1&#x000A;          }&#x000A;        ],&#x000A;        &quot;priority&quot;: 0&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
+<div class='section'>
+  <h1 class="title">
+    PUT schedules/:id
+  </h1>
+  <p>
+    Update an existing on-call schedule.
+  </p>
+  <div class='alert-info alert alert-block'>
+    <h4>
+      Note:
+    </h4>You cannot delete schedule layers. You must include all layers in your update request. To delete a layer, set the <code>end</code> parameter to schedule its termination. See the "Schedule Layer Parameters" section below for more information.
+  </div>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            overflow
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              Any on-call schedule entries that pass the date range bounds will be truncated at the bounds, unless the parameter <code>overflow=true</code> is passed. This parameter defaults to false.
+            </p>
+            <p>
+              For instance, if your schedule is a rotation that changes daily at midnight UTC, and your date range is from <code>2011-06-01T10:00:00Z</code> to <code>2011-06-01T14:00:00Z</code>:
+            </p>
+            <ul>
+              <li>If you <strong>don't</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T10:00:00Z</code> and <code>end</code> of <code>2011-06-01T14:00:00Z</code>.
+              </li>
+              <li>If you <strong>do</strong> pass the <code>overflow=true</code> parameter, you will get one schedule entry returned with a <code>start</code> of <code>2011-06-01T00:00:00Z</code> and <code>end</code> of <code>2011-06-02T00:00:00Z</code>.
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            schedule
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The schedule object. See schedule parameters for details.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Schedule Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            schedule_layers
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            A list of schedule layers. See the schedule layers parameters for details.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The time zone of the schedule.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Schedule Layer Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The unique identifier of the schedule layer to update. Omit this if creating a new schedule layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the schedule layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The start time of this layer.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            end
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end time of this layer. If null, the layer does not end.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            users
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            <p>
+              The ordered list of users on this layer. Use the member order to indicate their order.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "user": {
+        "id": "P2BI1SS"
+      },
+      "member_order": 1
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restriction_type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Can either be <code>Daily</code> or <code>Weekly</code>. Specifies the type of <code>restriction</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            restrictions
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              An array of restrictions for the layer. A restriction is a limit on which period of the day or week the schedule layer can accept events.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "restrictions": [
+    {
+      "duration_seconds": 43200,
+      "start_time_of_day": "00:00:00"
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_virtual_start
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The effective start time of the layer. This can be before the start time of the schedule.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            priority
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The priority of the layer. Layers with higher priority will override layers with a lower priority.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            rotation_turn_length_seconds
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The duration of each on-call shift in seconds.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{    
+      "since": "<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+      "until": "<span class='curl_params-until contenteditable' contenteditable='true'>2012-08-19T00:00:00</span>",
+      "overflow": 1,
+      "schedule": {
+        "time_zone": "<span class='curl_params-time_zone contenteditable' contenteditable='true'>UTC</span>",
+        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>new name</span>",
+        "schedule_layers": [
+          {
+            "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Schedule Layer 1</span>",
+            "id": "<span class='curl_params-id contenteditable' contenteditable='true'>P07F6S3</span>",
+            "start": "<span class='curl_params-start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "rotation_virtual_start": "<span class='curl_params-rotation_virtual_start contenteditable' contenteditable='true'>2012-08-05T00:00:00</span>",
+            "priority": 0,
+            "rotation_turn_length_seconds": 604800,
+            "users": [
+              {
+                "user": {
+                  "id": "<span class='curl_params-id contenteditable' contenteditable='true'>PPI9KUT</span>"
+                },
+                "member_order": 1
+              }
+            ],
+            "restriction_type": "<span class='curl_params-restriction_type contenteditable' contenteditable='true'>Daily</span>",
+            "restrictions": [
+              {
+                "duration_seconds": "<span class='curl_params-duration_seconds contenteditable' contenteditable='true'>43200</span>",
+                "start_time_of_day": "<span class='curl_params-start_time_of_day contenteditable' contenteditable='true'>00:00:00</span>"
+              }
+            ]
+          }
+        ]
+      }
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/:id"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "schedule": {
+    "today": "2012-08-24",
+    "overrides_subschedule": {
+      "name": "Overrides"
+    },
+    "final_schedule": {
+      "name": "Final Schedule"
+    },
+    "id": "P9UJCMM",
+    "name": "new name",
+    "time_zone": "UTC",
+    "escalation_policies": [
+
+    ],
+    "schedule_layers": [
+      {
+        "restrictions": [
+          {
+            "start_time_of_day": "00:00:00",
+            "duration_seconds": 43200
+          }
+        ],
+        "start": "2012-08-24T02:39:33Z",
+        "end": null,
+        "rotation_turn_length_seconds": 604800,
+        "rotation_virtual_start": "2012-08-05T00:00:00Z",
+        "restriction_type": "Daily",
+        "id": "P07F6S3",
+        "name": "Schedule Layer 1",
+        "users": [
+          {
+            "user": {
+              "color": "purple",
+              "id": "PPI9KUT",
+              "name": "Alan",
+              "email": "alankay@example.com"
+            },
+            "member_order": 1
+          }
+        ],
+        "priority": 0
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/schedules/users.html
+++ b/source/documentation/rest/schedules/users.html
@@ -2,11 +2,123 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/schedules">Schedules</a></li><span class="divider">/</span><li>Users</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/schedules">Schedules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Users
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET schedules/:id/users</h1><p>List all the users on-call in a given schedule for a given time range.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>/users</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>since</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The start of the date range over which you want to return on-call users.
-</td></tr><tr><td>until</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>No</td><td>The end time of the date range over which you want to return on-call users.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-01</span>" \&#x000A;    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/users"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;dark-orchid&quot;,&#x000A;      &quot;email&quot;: &quot;tierra.fritsch@example.com&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/f55521919f138925499b9c62f5291aac.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PTUXL6G&quot;,&#x000A;      &quot;invitation_sent&quot;: false,&#x000A;      &quot;role&quot;: &quot;owner&quot;,&#x000A;      &quot;name&quot;: &quot;Tierra Fritsch&quot;,&#x000A;      &quot;id&quot;: &quot;PTUXL6G&quot;&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET schedules/:id/users
+  </h1>
+  <p>
+    List all the users on-call in a given schedule for a given time range.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/schedules/<span class="url_param contenteditable" contenteditable="true">:id</span>/users
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            since
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The start of the date range over which you want to return on-call users.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            until
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The end time of the date range over which you want to return on-call users.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "since=<span class='curl_params-since contenteditable' contenteditable='true'>2012-08-01</span>" \
+    --data-urlencode "until=<span class='curl_params-until contenteditable' contenteditable='true'>2012-09-01</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/schedules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/users"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "dark-orchid",
+      "email": "tierra.fritsch@example.com",
+      "avatar_url": "https://secure.gravatar.com/avatar/f55521919f138925499b9c62f5291aac.png?d=mm&amp;r=PG",
+      "user_url": "/users/PTUXL6G",
+      "invitation_sent": false,
+      "role": "owner",
+      "name": "Tierra Fritsch",
+      "id": "PTUXL6G"
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/create.html
+++ b/source/documentation/rest/services/create.html
@@ -2,40 +2,357 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST services</h1><p>Create a new service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the service.
-</td></tr><tr><td>escalation_policy_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the escalation policy to be used by this service.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The type of service to create. Can be one of <code>generic_email</code>,
-<code>generic_events_api</code>, <code>keynote</code>, <code>nagios</code>, <code>pingdom</code>,
-<code>server_density</code> or <code>sql_monitor</code>.
-</td></tr><tr><td>vendor_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>PagerDuty's internal vendor identifier for this service. For more information about a specific vendor, please contact PagerDuty Support.</p>
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>A description for your service. 1024 character maximum.</p>
-</td></tr><tr><td>acknowledgement_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td><p>The duration in seconds before an incidents acknowledged in this service become triggered again.</p>
-<p>Defaults to 30 minutes.</p>
-</td></tr><tr><td>auto_resolve_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td><p>The duration in seconds before a triggered incident auto-resolves itself.</p>
-<p>Defaults to 4 hours.</p>
-</td></tr><tr><td>severity_filter</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Specifies what severity levels will create a new open incident.
-<p>For Keynote it can be one of:</p>
-<ul>
-<li><code>critical</code> Incidents are created when an alarm enters the Critical state</li>
-<li><code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states</li>
-</ul>
-For SQL Monitor it can be one of:
-<ul>
-<li><code>on_any</code> Incidents are created for alerts of any severity</li>
-<li><code>on_high</code> Incidents are created for alerts with high severity</li>
-<li><code>on_medium_high</code> Incidents are created for with high or medium severity</li>
-</ul>
-</td></tr></tbody></table></div><h4>Email specific settings</h4>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td><p>The service key for the service.</p>
-<p>Do not specify the domain. e.g. <code>my-service</code> rather than <code>my-service@my-subdomain.pagerduty.com</code></p>
-</td></tr><tr><td>email_incident_creation</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>only-if-no-open-incidents</code>, <code>on-new-email-subject</code>, or <code>on-new-email</code>.
-Defaults to <code>on-new-email</code>.
-</td></tr></tbody></table></div><h3>Example: Generic Email Service</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "service": {&#x000A;        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>default-email</span>",&#x000A;        "description": "<span class='curl_params-description contenteditable' contenteditable='true'>default email service</span>",&#x000A;        "escalation_policy_id": "<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>",&#x000A;        "type": "<span class='curl_params-type contenteditable' contenteditable='true'>generic_email</span>",&#x000A;        "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>default-email</span>"&#x000A;      }&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PY944Y7&quot;,&#x000A;    &quot;name&quot;: &quot;default-email&quot;,&#x000A;    &quot;service_url&quot;: &quot;/services/PY944Y7&quot;,&#x000A;    &quot;service_key&quot;: &quot;default-email@acme.pagerduty.com&quot;,&#x000A;    &quot;auto_resolve_timeout&quot;: 14400,&#x000A;    &quot;acknowledgement_timeout&quot;: 1800,&#x000A;    &quot;created_at&quot;: &quot;2012-11-15T21:29:54-05:00&quot;,&#x000A;    &quot;status&quot;: &quot;active&quot;,&#x000A;    &quot;last_incident_timestamp&quot;: null,&#x000A;    &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;    &quot;incident_counts&quot;: {&#x000A;      &quot;triggered&quot;: 0,&#x000A;      &quot;acknowledged&quot;: 0,&#x000A;      &quot;resolved&quot;: 0,&#x000A;      &quot;total&quot;: 0&#x000A;    },&#x000A;    &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;    &quot;type&quot;: &quot;generic_email&quot;,&#x000A;    &quot;description&quot;: &quot;default email service&quot;&#x000A;  }&#x000A;}</code></pre></div>
-<h3>Example: Generic API Service</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"service":{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>default</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>service sevname10</span>","escalation_policy_id":"<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>","type":"<span class='curl_params-type contenteditable' contenteditable='true'>generic_events_api</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code></pre>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PBIS5NX&quot;,&#x000A;    &quot;name&quot;: &quot;sevname10&quot;,&#x000A;    &quot;service_url&quot;: &quot;/services/PBIS5NX&quot;,&#x000A;    &quot;service_key&quot;: &quot;7b68a2c011c20130a61638f6b11a5d17&quot;,&#x000A;    &quot;auto_resolve_timeout&quot;: 14400,&#x000A;    &quot;acknowledgement_timeout&quot;: 1800,&#x000A;    &quot;created_at&quot;: &quot;2012-11-15T21:23:07-05:00&quot;,&#x000A;    &quot;status&quot;: &quot;active&quot;,&#x000A;    &quot;last_incident_timestamp&quot;: null,&#x000A;    &quot;email_incident_creation&quot;: null,&#x000A;    &quot;incident_counts&quot;: {&#x000A;      &quot;triggered&quot;: 0,&#x000A;      &quot;acknowledged&quot;: 0,&#x000A;      &quot;resolved&quot;: 0,&#x000A;      &quot;total&quot;: 0&#x000A;    },&#x000A;    &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;    &quot;type&quot;: &quot;generic_events_api&quot;,&#x000A;    &quot;description&quot;: &quot;service sevname10&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST services
+  </h1>
+  <p>
+    Create a new service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the escalation policy to be used by this service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The type of service to create. Can be one of <code>generic_email</code>, <code>generic_events_api</code>, <code>keynote</code>, <code>nagios</code>, <code>pingdom</code>, <code>server_density</code> or <code>sql_monitor</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            vendor_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              PagerDuty's internal vendor identifier for this service. For more information about a specific vendor, please contact PagerDuty Support.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              A description for your service. 1024 character maximum.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            acknowledgement_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The duration in seconds before an incidents acknowledged in this service become triggered again.
+            </p>
+            <p>
+              Defaults to 30 minutes.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            auto_resolve_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The duration in seconds before a triggered incident auto-resolves itself.
+            </p>
+            <p>
+              Defaults to 4 hours.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            severity_filter
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Specifies what severity levels will create a new open incident.
+            <p>
+              For Keynote it can be one of:
+            </p>
+            <ul>
+              <li>
+                <code>critical</code> Incidents are created when an alarm enters the Critical state
+              </li>
+              <li>
+                <code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states
+              </li>
+            </ul>For SQL Monitor it can be one of:
+            <ul>
+              <li>
+                <code>on_any</code> Incidents are created for alerts of any severity
+              </li>
+              <li>
+                <code>on_high</code> Incidents are created for alerts with high severity
+              </li>
+              <li>
+                <code>on_medium_high</code> Incidents are created for with high or medium severity
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h4>
+    Email specific settings
+  </h4>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            <p>
+              The service key for the service.
+            </p>
+            <p>
+              Do not specify the domain. e.g. <code>my-service</code> rather than <code>my-service@my-subdomain.pagerduty.com</code>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email_incident_creation
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>only-if-no-open-incidents</code>, <code>on-new-email-subject</code>, or <code>on-new-email</code>. Defaults to <code>on-new-email</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example: Generic Email Service
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "service": {
+        "name": "<span class='curl_params-name contenteditable' contenteditable='true'>default-email</span>",
+        "description": "<span class='curl_params-description contenteditable' contenteditable='true'>default email service</span>",
+        "escalation_policy_id": "<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>",
+        "type": "<span class='curl_params-type contenteditable' contenteditable='true'>generic_email</span>",
+        "service_key": "<span class='curl_params-service_key contenteditable' contenteditable='true'>default-email</span>"
+      }
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "service": {
+    "id": "PY944Y7",
+    "name": "default-email",
+    "service_url": "/services/PY944Y7",
+    "service_key": "default-email@acme.pagerduty.com",
+    "auto_resolve_timeout": 14400,
+    "acknowledgement_timeout": 1800,
+    "created_at": "2012-11-15T21:29:54-05:00",
+    "status": "active",
+    "last_incident_timestamp": null,
+    "email_incident_creation": "on_new_email_subject",
+    "incident_counts": {
+      "triggered": 0,
+      "acknowledged": 0,
+      "resolved": 0,
+      "total": 0
+    },
+    "email_filter_mode": "all-email",
+    "type": "generic_email",
+    "description": "default email service"
+  }
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example: Generic API Service
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"service":{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>default</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>service sevname10</span>","escalation_policy_id":"<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>","type":"<span class='curl_params-type contenteditable' contenteditable='true'>generic_events_api</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "service": {
+    "id": "PBIS5NX",
+    "name": "sevname10",
+    "service_url": "/services/PBIS5NX",
+    "service_key": "7b68a2c011c20130a61638f6b11a5d17",
+    "auto_resolve_timeout": 14400,
+    "acknowledgement_timeout": 1800,
+    "created_at": "2012-11-15T21:23:07-05:00",
+    "status": "active",
+    "last_incident_timestamp": null,
+    "email_incident_creation": null,
+    "incident_counts": {
+      "triggered": 0,
+      "acknowledged": 0,
+      "resolved": 0,
+      "total": 0
+    },
+    "email_filter_mode": "all-email",
+    "type": "generic_events_api",
+    "description": "service sevname10"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/delete.html
+++ b/source/documentation/rest/services/delete.html
@@ -2,9 +2,50 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE services/:id</h1><p>Delete an existing service. Once the service is deleted, it will not be accessible from the web UI and new incidents won&#x27;t be able to be created for this service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE services/:id
+  </h1>
+  <p>
+    Delete an existing service. Once the service is deleted, it will not be accessible from the web UI and new incidents won't be able to be created for this service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/services/disable.html
+++ b/source/documentation/rest/services/disable.html
@@ -2,10 +2,94 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Disable</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Disable
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT services/:id/disable</h1><p>Disable a service. Once a service is disabled, it will not be able to create incidents until it is enabled again.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/disable</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user creating the maintenance window. This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>"}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/disable"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{}</code></pre></div>
+  <h1 class="title">
+    PUT services/:id/disable
+  </h1>
+  <p>
+    Disable a service. Once a service is disabled, it will not be able to create incidents until it is enabled again.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/disable
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user creating the maintenance window. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"requester_id":"<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>"}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/disable"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/email_filters/create.html
+++ b/source/documentation/rest/services/email_filters/create.html
@@ -2,15 +2,180 @@
 title: PagerDuty Developers
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li><a href="/documentation/rest/services/email_filters">Email Filters</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services/email_filters">Email Filters</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST services/:service_id/email_filters</h1><p>Create a new Email Filter for the specified service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>subject_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by subject, filter it if the email subject matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>subject_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when subject_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr><tr><td>body_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by body, filter it if the body email matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>body_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when body_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr><tr><td>from_email_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by its from address, filter it if the email from address matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>from_email_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when from_email_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"email_filter":{"body_mode":"<span class='curl_params-body_mode contenteditable' contenteditable='true'>no-match</span>","body_regex":"<span class='curl_params-body_regex contenteditable' contenteditable='true'>sev 3</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;email_filter&quot;: {&#x000A;    &quot;subject_mode&quot;: &quot;always&quot;,&#x000A;    &quot;subject_regex&quot;: null,&#x000A;    &quot;body_mode&quot;: &quot;no-match&quot;,&#x000A;    &quot;body_regex&quot;: &quot;sev 3&quot;,&#x000A;    &quot;from_email_mode&quot;: &quot;always&quot;,&#x000A;    &quot;from_email_regex&quot;: null,&#x000A;    &quot;id&quot;: &quot;PM1H1PY&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST services/:service_id/email_filters
+  </h1>
+  <p>
+    Create a new Email Filter for the specified service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            subject_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by subject, filter it if the email subject matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            subject_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when subject_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            body_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by body, filter it if the body email matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            body_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when body_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            from_email_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by its from address, filter it if the email from address matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            from_email_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when from_email_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"email_filter":{"body_mode":"<span class='curl_params-body_mode contenteditable' contenteditable='true'>no-match</span>","body_regex":"<span class='curl_params-body_regex contenteditable' contenteditable='true'>sev 3</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "email_filter": {
+    "subject_mode": "always",
+    "subject_regex": null,
+    "body_mode": "no-match",
+    "body_regex": "sev 3",
+    "from_email_mode": "always",
+    "from_email_regex": null,
+    "id": "PM1H1PY"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/email_filters/delete.html
+++ b/source/documentation/rest/services/email_filters/delete.html
@@ -2,9 +2,56 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li><a href="/documentation/rest/services/email_filters">Email Filters</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services/email_filters">Email Filters</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE services/:service_id/email_filters/:id</h1><p>Delete an existing Email Filter.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PM1H1PY</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE services/:service_id/email_filters/:id
+  </h1>
+  <p>
+    Delete an existing Email Filter.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PM1H1PY</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/services/email_filters/index.html
+++ b/source/documentation/rest/services/email_filters/index.html
@@ -2,9 +2,65 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Email Filters</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Email Filters
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Email Filters API</h1>
-<table class="table action_index"><caption>Email Filters are a set of rules that are applied to triggering email's body, subject and from address. It only applies to <code>generic_email</code> kind of Services. The way multiple filters are combined depends on the <a href="/documentation/rest/services/list">email_filter_mode</a> attribute of the service.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/services/email_filters/create">POST services/:service_id/email_filters</a></td><td>Create a new Email Filter for the specified service.</td></tr><tr><td><a href="/documentation/rest/services/email_filters/update">PUT services/:service_id/email_filters/:id</a></td><td>Update an existing Email Filter.</td></tr><tr><td><a href="/documentation/rest/services/email_filters/delete">DELETE services/:service_id/email_filters/:id</a></td><td>Delete an existing Email Filter.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Email Filters API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      Email Filters are a set of rules that are applied to triggering email's body, subject and from address. It only applies to <code>generic_email</code> kind of Services. The way multiple filters are combined depends on the <a href="/documentation/rest/services/list">email_filter_mode</a> attribute of the service.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/email_filters/create">POST services/:service_id/email_filters</a>
+        </td>
+        <td>
+          Create a new Email Filter for the specified service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/email_filters/update">PUT services/:service_id/email_filters/:id</a>
+        </td>
+        <td>
+          Update an existing Email Filter.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/email_filters/delete">DELETE services/:service_id/email_filters/:id</a>
+        </td>
+        <td>
+          Delete an existing Email Filter.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/services/email_filters/update.html
+++ b/source/documentation/rest/services/email_filters/update.html
@@ -2,15 +2,180 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li><a href="/documentation/rest/services/email_filters">Email Filters</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services/email_filters">Email Filters</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT services/:service_id/email_filters/:id</h1><p>Update an existing Email Filter.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>subject_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by subject, filter it if the email subject matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>subject_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when subject_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr><tr><td>body_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by body, filter it if the body email matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>body_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when body_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr><tr><td>from_email_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by its from address, filter it if the email from address matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
-</td></tr><tr><td>from_email_regex</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The regex to be used when from_email_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"email_filter":{"from_email_mode":"<span class='curl_params-from_email_mode contenteditable' contenteditable='true'>match</span>","from_email_regex":"<span class='curl_params-from_email_regex contenteditable' contenteditable='true'>[rR]yan</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PM1H1PY</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;email_filter&quot;: {&#x000A;    &quot;subject_mode&quot;: &quot;always&quot;,&#x000A;    &quot;subject_regex&quot;: null,&#x000A;    &quot;body_mode&quot;: &quot;no-match&quot;,&#x000A;    &quot;body_regex&quot;: &quot;sev 3&quot;,&#x000A;    &quot;from_email_mode&quot;: &quot;match&quot;,&#x000A;    &quot;from_email_regex&quot;: &quot;[rR]yan&quot;,&#x000A;    &quot;id&quot;: &quot;PM1H1PY&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT services/:service_id/email_filters/:id
+  </h1>
+  <p>
+    Update an existing Email Filter.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:service_id</span>/email_filters/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            subject_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by subject, filter it if the email subject matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            subject_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when subject_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            body_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by body, filter it if the body email matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            body_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when body_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            from_email_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>always</code>, <code>match</code>, <code>no-match</code>, which, respectively, means to not filter the email trigger by its from address, filter it if the email from address matches the given regex, or filter if it doesn't match the given regex. Defaults to <code>always</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            from_email_regex
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The regex to be used when from_email_mode is <code>match</code> or <code>no-match</code>. It is a required parameter on such cases.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"email_filter":{"from_email_mode":"<span class='curl_params-from_email_mode contenteditable' contenteditable='true'>match</span>","from_email_regex":"<span class='curl_params-from_email_regex contenteditable' contenteditable='true'>[rR]yan</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-service_id service_id contenteditable" contenteditable="true">P9312OW</span>/email_filters/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PM1H1PY</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "email_filter": {
+    "subject_mode": "always",
+    "subject_regex": null,
+    "body_mode": "no-match",
+    "body_regex": "sev 3",
+    "from_email_mode": "match",
+    "from_email_regex": "[rR]yan",
+    "id": "PM1H1PY"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/enable.html
+++ b/source/documentation/rest/services/enable.html
@@ -2,9 +2,54 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Enable</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Enable
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT services/:id/enable</h1><p>Enable a previously disabled service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/enable</pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/enable"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{}</code></pre></div>
+  <h1 class="title">
+    PUT services/:id/enable
+  </h1>
+  <p>
+    Enable a previously disabled service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/enable
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/enable"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/index.html
+++ b/source/documentation/rest/services/index.html
@@ -2,15 +2,105 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Services</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Services
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Services API</h1>
-<p>A service is an endpoint (like Nagios, email, or an API call) that generates events, which Pagerduty normalizes and dedupes, creating <a href="/documentation/rest/incidents">incidents</a>.</p>
-<p>When a service is shown inlined in other resources, a deleted service will have its html_url attribute set to null.</p>
-<table class="table action_index"><caption>This API lets you access and manipulate the services across your account.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/services/list">GET services</a></td><td>List existing services.</td></tr><tr><td><a href="/documentation/rest/services/show">GET services/:id</a></td><td>Get details about an existing service.</td></tr>
-<tr><td><a href="/documentation/rest/services/create">POST services</a></td><td>Create a new service.</td></tr><tr><td><a href="/documentation/rest/services/update">PUT services/:id</a></td><td>Update an existing service.</td></tr><tr><td><a href="/documentation/rest/services/delete">DELETE services/:id</a></td><td>Delete an existing service. Once the service is deleted, it will not be accessible from the web UI and new incidents won't be able to be created for this service.</td></tr>
-<tr><td><a href="/documentation/rest/services/disable">PUT services/:id/disable</a></td><td>Disable a service. Once a service is disabled, it will not be able to create incidents until it is enabled again.</td></tr>
-<tr><td><a href="/documentation/rest/services/enable">PUT services/:id/enable</a></td><td>Enable a previously disabled service.</td></tr>
-<tr><td><a href="/documentation/rest/services/regenerate_key">POST services/:id/regenerate_key</a></td><td>Regenerate a new service key for an existing service.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Services API
+  </h1>
+  <p>
+    A service is an endpoint (like Nagios, email, or an API call) that generates events, which Pagerduty normalizes and dedupes, creating <a href="/documentation/rest/incidents">incidents</a>.
+  </p>
+  <p>
+    When a service is shown inlined in other resources, a deleted service will have its html_url attribute set to null.
+  </p>
+  <table class="table action_index">
+    <caption>
+      This API lets you access and manipulate the services across your account.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/list">GET services</a>
+        </td>
+        <td>
+          List existing services.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/show">GET services/:id</a>
+        </td>
+        <td>
+          Get details about an existing service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/create">POST services</a>
+        </td>
+        <td>
+          Create a new service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/update">PUT services/:id</a>
+        </td>
+        <td>
+          Update an existing service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/delete">DELETE services/:id</a>
+        </td>
+        <td>
+          Delete an existing service. Once the service is deleted, it will not be accessible from the web UI and new incidents won't be able to be created for this service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/disable">PUT services/:id/disable</a>
+        </td>
+        <td>
+          Disable a service. Once a service is disabled, it will not be able to create incidents until it is enabled again.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/enable">PUT services/:id/enable</a>
+        </td>
+        <td>
+          Enable a previously disabled service.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/services/regenerate_key">POST services/:id/regenerate_key</a>
+        </td>
+        <td>
+          Regenerate a new service key for an existing service.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/services/list.html
+++ b/source/documentation/rest/services/list.html
@@ -2,69 +2,846 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET services</h1><p>List existing services.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Include extra information in the response. Possible values are <code>escalation_policy</code> (for inline Escalation Policy) and <code>email_filters</code> (for inline <a href="/documentation/rest/services/email_filters">Email Filters</a>).
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>Time zone in which dates in the result will be rendered. Defaults to account default time zone.
-</td></tr></tbody></table></div><h3>Response Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>A unique identifier for this service.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the service.
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>The description of the service
-</td></tr><tr><td>service_url</td><td><a href="/documentation/rest/types#string">String</a></td><td>Relative URL that corresponds to this service. Can be appended to https://&lt;subdomain>.pagerduty.com to view service information.
-</td></tr><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>For Email services, the service_key is the associated email address for the service. For all other service types, this is the unique key used for API calls.
-</td></tr><tr><td>auto_resolve_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Time in seconds that an incident is automatically resolved if left open for that long. Value is "null" is the feature is disabled.
-</td></tr><tr><td>acknowledgement_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is "null" is the feature is disabled.
-</td></tr><tr><td>created_at</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The date/time when this service was created
-</td></tr><tr><td>status</td><td><a href="/documentation/rest/types#string">String</a></td><td>The current state of the Service. Valid statuses are:
-<ul>
-<li><code>active</code> The service is enabled and has no open incidents.</li>
-<li><code>warning</code> The service is enabled and has one or more acknowledged incidents.</li>
-<li><code>critical</code> The service is enabled and has one or more triggered incidents.</li>
-<li><code>maintenance</code> The service is under maintenance, no new incidents will be triggered during maintenance mode.</li>
-<li><code>disabled</code> The service is disabled and will not have any new triggered incidents.</li>
-</ul>
-</td></tr><tr><td>last_incident_timestamp</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>The date/time when the most recent incident was created for this service.
-</td></tr><tr><td>email_incident_creation</td><td><a href="/documentation/rest/types#string">String</a></td><td>If the service is a Generic Email service, this describes what kind of emails create an incident.
-<ul>
-<li><code>on_new_email</code> Open a new incident for each trigger email.</li>
-<li><code>on_new_email_subject</code> Open a new incident for each new trigger email subject.</li>
-<li><code>only_if_no_open_incidents</code> Open a new incident only if an open incident does not already exist.</li>
-</ul>
-</td></tr><tr><td>incident_counts</td><td><a href="/documentation/rest/types#object">Object</a></td><td>An object with the number of incidents corresponding to these states: <code>triggered</code> <code>acknowledged</code> <code>resolved</code> <code>total</code>
-</td></tr><tr><td>email_filter_mode</td><td><a href="/documentation/rest/types#string">String</a></td><td>If the service is a Generic Email service, this describes which types of email will generate an incident. Valid values are:
-<ul>
-<li><code>all-email</code> Accept all incoming email</li>
-<li><code>or-rules-email</code> Accept email only if it matches ONE OR MORE rules below</li>
-<li><code>and-rules-email</code> Accept email only if it matches ALL of the rules below</li>
-</ul>
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>The service type. Valid values are:
-<ul>
-<li><code>cloudkick</code></li>
-<li><code>generic_email</code></li>
-<li><code>generic_events_api</code></li>
-<li><code>keynote</code></li>
-<li><code>nagios</code></li>
-<li><code>pingdom</code></li>
-<li><code>server_density</code></li>
-<li><code>sql_monitor</code></li>
-</ul>
-</td></tr><tr><td>escalation_policy</td><td><a href="/documentation/rest/types#object">Object</a></td><td>An object containing the ID and name of the escalation policy used by this service. Only present if <code>escalation_policy</code> is passed as an argument.
-</td></tr><tr><td>email_filters</td><td><a href="/documentation/rest/types#object">Object</a></td><td>An object containing inline <a href="/documentation/rest/services/email_filters">Email Filters</a>. Only present if <code>email_filters</code> is passed as an argument. Note that only <code>generic_email</code> services have Email Filters.
-</td></tr><tr><td>severity_filter</td><td><a href="/documentation/rest/types#string">String</a></td><td>Specifies what severity levels will create a new open incident.
-<p>For Keynote it can be one of:</p>
-<ul>
-<li><code>critical</code> Incidents are created when an alarm enters the Critical state</li>
-<li><code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states</li>
-</ul>
-For SQL Monitor it can be one of:
-<ul>
-<li><code>on_any</code> Incidents are created for alerts of any severity</li>
-<li><code>on_high</code> Incidents are created for alerts with high severity</li>
-<li><code>on_medium_high</code> Incidents are created for with high or medium severity</li>
-</ul>
-</td></tr></tbody></table></div><h3>Example 1:</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>escalation_policy</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;services&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PYKZNA9&quot;,&#x000A;      &quot;name&quot;: &quot;a&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PYKZNA9&quot;,&#x000A;      &quot;service_key&quot;: &quot;a@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-14T17:22:56-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service a&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PO2C8W6&quot;,&#x000A;      &quot;name&quot;: &quot;aa&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PO2C8W6&quot;,&#x000A;      &quot;service_key&quot;: &quot;aa@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-15T18:43:56-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service as&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PSQVSNY&quot;,&#x000A;      &quot;name&quot;: &quot;adsfadsfads&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PSQVSNY&quot;,&#x000A;      &quot;service_key&quot;: &quot;adsfadsfads@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-12T22:33:51-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service adsfadsfads&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PVOO9KJ&quot;,&#x000A;      &quot;name&quot;: &quot;aff&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PVOO9KJ&quot;,&#x000A;      &quot;service_key&quot;: &quot;aff@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-14T18:12:31-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service aff&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PEYSGVF&quot;,&#x000A;      &quot;name&quot;: &quot;cloud&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PEYSGVF&quot;,&#x000A;      &quot;service_key&quot;: &quot;2b4310400d360130777138f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T00:22:31-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;critical&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: &quot;2012-11-08T19:22:07-05:00&quot;,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 1,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 1&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;cloudkick&quot;,&#x000A;      &quot;description&quot;: &quot;service cloud&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PF9KMXH&quot;,&#x000A;      &quot;name&quot;: &quot;defa&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;      &quot;service_key&quot;: &quot;amazing2@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: null,&#x000A;      &quot;acknowledgement_timeout&quot;: null,&#x000A;      &quot;created_at&quot;: &quot;2012-08-15T20:15:52-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: &quot;2012-09-12T17:57:06-04:00&quot;,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 4,&#x000A;        &quot;total&quot;: 4&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;or-rules-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service defa&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P573W8X&quot;,&#x000A;      &quot;name&quot;: &quot;djaljdlds&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/P573W8X&quot;,&#x000A;      &quot;service_key&quot;: &quot;djaljdlds@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-09T18:48:14-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;or-rules-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service djaljdlds&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PQ47DCP&quot;,&#x000A;      &quot;name&quot;: &quot;dservicer&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PQ47DCP&quot;,&#x000A;      &quot;service_key&quot;: &quot;450c73c00f350130777538f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T00:34:55-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;server_density&quot;,&#x000A;      &quot;description&quot;: &quot;service dservicer&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHW8B63&quot;,&#x000A;      &quot;name&quot;: &quot;f&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PHW8B63&quot;,&#x000A;      &quot;service_key&quot;: &quot;f@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-05T17:34:34-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;disabled&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;or-rules-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service f&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PAM4FGS&quot;,&#x000A;      &quot;name&quot;: &quot;keynoted&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PAM4FGS&quot;,&#x000A;      &quot;service_key&quot;: &quot;keynoted@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T00:26:52-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;keynote&quot;,&#x000A;      &quot;severity_filter&quot;: &quot;critical_or_warning&quot;,&#x000A;      &quot;description&quot;: &quot;service keynoted&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P9UJCMM&quot;,&#x000A;      &quot;name&quot;: &quot;le monitor&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/P9UJCMM&quot;,&#x000A;      &quot;service_key&quot;: &quot;le-monitor@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T00:35:18-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;or-rules-email&quot;,&#x000A;      &quot;type&quot;: &quot;sql_monitor&quot;,&#x000A;      &quot;severity_filter&quot;: &quot;on_medium_high&quot;,&#x000A;      &quot;description&quot;: &quot;service le monitor&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;      &quot;name&quot;: &quot;MyApi&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PBAZLIU&quot;,&#x000A;      &quot;service_key&quot;: &quot;28198a20cae6012f5c6c38f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-08-17T18:09:37-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: &quot;2011-04-21T04:26:37-04:00&quot;,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 4,&#x000A;        &quot;total&quot;: 4&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_events_api&quot;,&#x000A;      &quot;description&quot;: &quot;service MyApi&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PXPGF42&quot;,&#x000A;      &quot;name&quot;: &quot;nagiosed&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PXPGF42&quot;,&#x000A;      &quot;service_key&quot;: &quot;4f7a977006d401305df938f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T00:33:01-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;nagios&quot;,&#x000A;      &quot;description&quot;: &quot;service nagiosed&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PDJKATD&quot;,&#x000A;      &quot;name&quot;: &quot;nagnag&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PDJKATD&quot;,&#x000A;      &quot;service_key&quot;: &quot;b2977ea00f5e01307d2338f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-05T18:34:53-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;nagios&quot;,&#x000A;      &quot;description&quot;: &quot;service nagnag&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P29NBY9&quot;,&#x000A;      &quot;name&quot;: &quot;serverd&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/P29NBY9&quot;,&#x000A;      &quot;service_key&quot;: &quot;0b2f05b00f6201307d2538f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-02T20:56:39-04:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;server_density&quot;,&#x000A;      &quot;description&quot;: &quot;service served&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PT20YPA&quot;,&#x000A;      &quot;name&quot;: &quot;sevname&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PT20YPA&quot;,&#x000A;      &quot;service_key&quot;: &quot;sevname@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-09T01:03:10-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service sevname&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P7TR7GG&quot;,&#x000A;      &quot;name&quot;: &quot;sevname1011&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/P7TR7GG&quot;,&#x000A;      &quot;service_key&quot;: &quot;726602c011bf0130a60d38f6b11a5d17&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-15T21:01:24-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: null,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_events_api&quot;,&#x000A;      &quot;description&quot;: &quot;service sevname1011&quot;&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PQFCJER&quot;,&#x000A;      &quot;name&quot;: &quot;Thingy&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PQFCJER&quot;,&#x000A;      &quot;service_key&quot;: &quot;thingy@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2011-01-08T00:22:24-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;active&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: null,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 0,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 0&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;description&quot;: &quot;service Thingy&quot;&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 18&#x000A;}</code></pre></div>
-<h3>Example 2: Including Email Filters</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>email_filters</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code></pre>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;services&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PYKZNA9&quot;,&#x000A;      &quot;name&quot;: &quot;a&quot;,&#x000A;      &quot;service_url&quot;: &quot;/services/PYKZNA9&quot;,&#x000A;      &quot;service_key&quot;: &quot;a@acme.pagerduty.com&quot;,&#x000A;      &quot;auto_resolve_timeout&quot;: 14400,&#x000A;      &quot;acknowledgement_timeout&quot;: 1800,&#x000A;      &quot;created_at&quot;: &quot;2012-11-14T17:22:56-05:00&quot;,&#x000A;      &quot;status&quot;: &quot;critical&quot;,&#x000A;      &quot;last_incident_timestamp&quot;: &quot;2012-11-16T22:51:17-05:00&quot;,&#x000A;      &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;      &quot;incident_counts&quot;: {&#x000A;        &quot;triggered&quot;: 1,&#x000A;        &quot;acknowledged&quot;: 0,&#x000A;        &quot;resolved&quot;: 0,&#x000A;        &quot;total&quot;: 1&#x000A;      },&#x000A;      &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;      &quot;type&quot;: &quot;generic_email&quot;,&#x000A;      &quot;email_filters&quot;: [&#x000A;        {&#x000A;          &quot;subject_mode&quot;: &quot;always&quot;,&#x000A;          &quot;subject_regex&quot;: null,&#x000A;          &quot;body_mode&quot;: &quot;always&quot;,&#x000A;          &quot;body_regex&quot;: null,&#x000A;          &quot;from_email_mode&quot;: &quot;match&quot;,&#x000A;          &quot;from_email_regex&quot;: &quot;[rR]yan&quot;,&#x000A;          &quot;id&quot;: &quot;PCWKOPZ&quot;&#x000A;        }&#x000A;      ]&#x000A;    }&#x000A;  ],&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET services
+  </h1>
+  <p>
+    List existing services.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Include extra information in the response. Possible values are <code>escalation_policy</code> (for inline Escalation Policy) and <code>email_filters</code> (for inline <a href="/documentation/rest/services/email_filters">Email Filters</a>).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Time zone in which dates in the result will be rendered. Defaults to account default time zone.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A unique identifier for this service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The description of the service
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service_url
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Relative URL that corresponds to this service. Can be appended to https://&lt;subdomain&gt;.pagerduty.com to view service information.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            For Email services, the service_key is the associated email address for the service. For all other service types, this is the unique key used for API calls.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            auto_resolve_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Time in seconds that an incident is automatically resolved if left open for that long. Value is "null" is the feature is disabled.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            acknowledgement_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Time in seconds that an incident changes to the Triggered State after being Acknowledged. Value is "null" is the feature is disabled.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            created_at
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The date/time when this service was created
+          </td>
+        </tr>
+        <tr>
+          <td>
+            status
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The current state of the Service. Valid statuses are:
+            <ul>
+              <li>
+                <code>active</code> The service is enabled and has no open incidents.
+              </li>
+              <li>
+                <code>warning</code> The service is enabled and has one or more acknowledged incidents.
+              </li>
+              <li>
+                <code>critical</code> The service is enabled and has one or more triggered incidents.
+              </li>
+              <li>
+                <code>maintenance</code> The service is under maintenance, no new incidents will be triggered during maintenance mode.
+              </li>
+              <li>
+                <code>disabled</code> The service is disabled and will not have any new triggered incidents.
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            last_incident_timestamp
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            The date/time when the most recent incident was created for this service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email_incident_creation
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            If the service is a Generic Email service, this describes what kind of emails create an incident.
+            <ul>
+              <li>
+                <code>on_new_email</code> Open a new incident for each trigger email.
+              </li>
+              <li>
+                <code>on_new_email_subject</code> Open a new incident for each new trigger email subject.
+              </li>
+              <li>
+                <code>only_if_no_open_incidents</code> Open a new incident only if an open incident does not already exist.
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident_counts
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            An object with the number of incidents corresponding to these states: <code>triggered</code> <code>acknowledged</code> <code>resolved</code> <code>total</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email_filter_mode
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            If the service is a Generic Email service, this describes which types of email will generate an incident. Valid values are:
+            <ul>
+              <li>
+                <code>all-email</code> Accept all incoming email
+              </li>
+              <li>
+                <code>or-rules-email</code> Accept email only if it matches ONE OR MORE rules below
+              </li>
+              <li>
+                <code>and-rules-email</code> Accept email only if it matches ALL of the rules below
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The service type. Valid values are:
+            <ul>
+              <li>
+                <code>cloudkick</code>
+              </li>
+              <li>
+                <code>generic_email</code>
+              </li>
+              <li>
+                <code>generic_events_api</code>
+              </li>
+              <li>
+                <code>keynote</code>
+              </li>
+              <li>
+                <code>nagios</code>
+              </li>
+              <li>
+                <code>pingdom</code>
+              </li>
+              <li>
+                <code>server_density</code>
+              </li>
+              <li>
+                <code>sql_monitor</code>
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            An object containing the ID and name of the escalation policy used by this service. Only present if <code>escalation_policy</code> is passed as an argument.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email_filters
+          </td>
+          <td>
+            <a href="/documentation/rest/types#object">Object</a>
+          </td>
+          <td>
+            An object containing inline <a href="/documentation/rest/services/email_filters">Email Filters</a>. Only present if <code>email_filters</code> is passed as an argument. Note that only <code>generic_email</code> services have Email Filters.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            severity_filter
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Specifies what severity levels will create a new open incident.
+            <p>
+              For Keynote it can be one of:
+            </p>
+            <ul>
+              <li>
+                <code>critical</code> Incidents are created when an alarm enters the Critical state
+              </li>
+              <li>
+                <code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states
+              </li>
+            </ul>For SQL Monitor it can be one of:
+            <ul>
+              <li>
+                <code>on_any</code> Incidents are created for alerts of any severity
+              </li>
+              <li>
+                <code>on_high</code> Incidents are created for alerts with high severity
+              </li>
+              <li>
+                <code>on_medium_high</code> Incidents are created for with high or medium severity
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example 1:
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>escalation_policy</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "services": [
+    {
+      "id": "PYKZNA9",
+      "name": "a",
+      "service_url": "/services/PYKZNA9",
+      "service_key": "a@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-14T17:22:56-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service a"
+    },
+    {
+      "id": "PO2C8W6",
+      "name": "aa",
+      "service_url": "/services/PO2C8W6",
+      "service_key": "aa@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-15T18:43:56-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service as"
+    },
+    {
+      "id": "PSQVSNY",
+      "name": "adsfadsfads",
+      "service_url": "/services/PSQVSNY",
+      "service_key": "adsfadsfads@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-12T22:33:51-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service adsfadsfads"
+    },
+    {
+      "id": "PVOO9KJ",
+      "name": "aff",
+      "service_url": "/services/PVOO9KJ",
+      "service_key": "aff@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-14T18:12:31-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service aff"
+    },
+    {
+      "id": "PEYSGVF",
+      "name": "cloud",
+      "service_url": "/services/PEYSGVF",
+      "service_key": "2b4310400d360130777138f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T00:22:31-04:00",
+      "status": "critical",
+      "last_incident_timestamp": "2012-11-08T19:22:07-05:00",
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 1,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 1
+      },
+      "email_filter_mode": "all-email",
+      "type": "cloudkick",
+      "description": "service cloud"
+    },
+    {
+      "id": "PF9KMXH",
+      "name": "defa",
+      "service_url": "/services/PF9KMXH",
+      "service_key": "amazing2@acme.pagerduty.com",
+      "auto_resolve_timeout": null,
+      "acknowledgement_timeout": null,
+      "created_at": "2012-08-15T20:15:52-04:00",
+      "status": "active",
+      "last_incident_timestamp": "2012-09-12T17:57:06-04:00",
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 4,
+        "total": 4
+      },
+      "email_filter_mode": "or-rules-email",
+      "type": "generic_email",
+      "description": "service defa"
+    },
+    {
+      "id": "P573W8X",
+      "name": "djaljdlds",
+      "service_url": "/services/P573W8X",
+      "service_key": "djaljdlds@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-09T18:48:14-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "or-rules-email",
+      "type": "generic_email",
+      "description": "service djaljdlds"
+    },
+    {
+      "id": "PQ47DCP",
+      "name": "dservicer",
+      "service_url": "/services/PQ47DCP",
+      "service_key": "450c73c00f350130777538f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T00:34:55-04:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "server_density",
+      "description": "service dservicer"
+    },
+    {
+      "id": "PHW8B63",
+      "name": "f",
+      "service_url": "/services/PHW8B63",
+      "service_key": "f@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-05T17:34:34-05:00",
+      "status": "disabled",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "or-rules-email",
+      "type": "generic_email",
+      "description": "service f"
+    },
+    {
+      "id": "PAM4FGS",
+      "name": "keynoted",
+      "service_url": "/services/PAM4FGS",
+      "service_key": "keynoted@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T00:26:52-04:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "keynote",
+      "severity_filter": "critical_or_warning",
+      "description": "service keynoted"
+    },
+    {
+      "id": "P9UJCMM",
+      "name": "le monitor",
+      "service_url": "/services/P9UJCMM",
+      "service_key": "le-monitor@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T00:35:18-04:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "or-rules-email",
+      "type": "sql_monitor",
+      "severity_filter": "on_medium_high",
+      "description": "service le monitor"
+    },
+    {
+      "id": "PBAZLIU",
+      "name": "MyApi",
+      "service_url": "/services/PBAZLIU",
+      "service_key": "28198a20cae6012f5c6c38f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-08-17T18:09:37-04:00",
+      "status": "active",
+      "last_incident_timestamp": "2011-04-21T04:26:37-04:00",
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 4,
+        "total": 4
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_events_api",
+      "description": "service MyApi"
+    },
+    {
+      "id": "PXPGF42",
+      "name": "nagiosed",
+      "service_url": "/services/PXPGF42",
+      "service_key": "4f7a977006d401305df938f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T00:33:01-04:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "nagios",
+      "description": "service nagiosed"
+    },
+    {
+      "id": "PDJKATD",
+      "name": "nagnag",
+      "service_url": "/services/PDJKATD",
+      "service_key": "b2977ea00f5e01307d2338f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-05T18:34:53-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "nagios",
+      "description": "service nagnag"
+    },
+    {
+      "id": "P29NBY9",
+      "name": "serverd",
+      "service_url": "/services/P29NBY9",
+      "service_key": "0b2f05b00f6201307d2538f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-02T20:56:39-04:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "server_density",
+      "description": "service served"
+    },
+    {
+      "id": "PT20YPA",
+      "name": "sevname",
+      "service_url": "/services/PT20YPA",
+      "service_key": "sevname@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-09T01:03:10-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service sevname"
+    },
+    {
+      "id": "P7TR7GG",
+      "name": "sevname1011",
+      "service_url": "/services/P7TR7GG",
+      "service_key": "726602c011bf0130a60d38f6b11a5d17",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-15T21:01:24-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": null,
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_events_api",
+      "description": "service sevname1011"
+    },
+    {
+      "id": "PQFCJER",
+      "name": "Thingy",
+      "service_url": "/services/PQFCJER",
+      "service_key": "thingy@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2011-01-08T00:22:24-05:00",
+      "status": "active",
+      "last_incident_timestamp": null,
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 0,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 0
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "description": "service Thingy"
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 18
+}</code>
+</pre>
+  </div>
+  <h3>
+    Example 2: Including Email Filters
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>email_filters</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services"</code>
+</pre>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "services": [
+    {
+      "id": "PYKZNA9",
+      "name": "a",
+      "service_url": "/services/PYKZNA9",
+      "service_key": "a@acme.pagerduty.com",
+      "auto_resolve_timeout": 14400,
+      "acknowledgement_timeout": 1800,
+      "created_at": "2012-11-14T17:22:56-05:00",
+      "status": "critical",
+      "last_incident_timestamp": "2012-11-16T22:51:17-05:00",
+      "email_incident_creation": "on_new_email_subject",
+      "incident_counts": {
+        "triggered": 1,
+        "acknowledged": 0,
+        "resolved": 0,
+        "total": 1
+      },
+      "email_filter_mode": "all-email",
+      "type": "generic_email",
+      "email_filters": [
+        {
+          "subject_mode": "always",
+          "subject_regex": null,
+          "body_mode": "always",
+          "body_regex": null,
+          "from_email_mode": "match",
+          "from_email_regex": "[rR]yan",
+          "id": "PCWKOPZ"
+        }
+      ]
+    }
+  ],
+  "limit": 25,
+  "offset": 0,
+  "total": 1
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/regenerate_key.html
+++ b/source/documentation/rest/services/regenerate_key.html
@@ -2,14 +2,79 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Regenerate Key</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Regenerate Key
+  </li>
+</ul>
 <div class='section'>
-<div class='alert'>
-<strong>Warning!</strong>
-The service's previous key will be invalidated, and existing monitoring integrations will
-need to be modified to use the new key!
-</div>
-<h1 class="title">POST services/:id/regenerate_key</h1><p>Regenerate a new service key for an existing service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/regenerate_key</pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBIS5NX</span>/regenerate_key"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PBIS5NX&quot;,&#x000A;    &quot;name&quot;: &quot;sevname10&quot;,&#x000A;    &quot;service_url&quot;: &quot;/services/PBIS5NX&quot;,&#x000A;    &quot;service_key&quot;: &quot;7b68a2c011c20130a61638f6b11a5d17&quot;,&#x000A;    &quot;auto_resolve_timeout&quot;: 14400,&#x000A;    &quot;acknowledgement_timeout&quot;: 1800,&#x000A;    &quot;created_at&quot;: &quot;2012-11-15T21:23:07-05:00&quot;,&#x000A;    &quot;status&quot;: &quot;active&quot;,&#x000A;    &quot;last_incident_timestamp&quot;: null,&#x000A;    &quot;email_incident_creation&quot;: null,&#x000A;    &quot;incident_counts&quot;: {&#x000A;      &quot;triggered&quot;: 0,&#x000A;      &quot;acknowledged&quot;: 0,&#x000A;      &quot;resolved&quot;: 0,&#x000A;      &quot;total&quot;: 0&#x000A;    },&#x000A;    &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;    &quot;type&quot;: &quot;generic_events_api&quot;,&#x000A;    &quot;description&quot;: &quot;service sevname10&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <div class='alert'>
+    <strong>Warning!</strong> The service's previous key will be invalidated, and existing monitoring integrations will need to be modified to use the new key!
+  </div>
+  <h1 class="title">
+    POST services/:id/regenerate_key
+  </h1>
+  <p>
+    Regenerate a new service key for an existing service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>/regenerate_key
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBIS5NX</span>/regenerate_key"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "service": {
+    "id": "PBIS5NX",
+    "name": "sevname10",
+    "service_url": "/services/PBIS5NX",
+    "service_key": "7b68a2c011c20130a61638f6b11a5d17",
+    "auto_resolve_timeout": 14400,
+    "acknowledgement_timeout": 1800,
+    "created_at": "2012-11-15T21:23:07-05:00",
+    "status": "active",
+    "last_incident_timestamp": null,
+    "email_incident_creation": null,
+    "incident_counts": {
+      "triggered": 0,
+      "acknowledged": 0,
+      "resolved": 0,
+      "total": 0
+    },
+    "email_filter_mode": "all-email",
+    "type": "generic_events_api",
+    "description": "service sevname10"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/show.html
+++ b/source/documentation/rest/services/show.html
@@ -5,10 +5,115 @@ permalink: /documentation/rest/services/show/
 redirect_from:
   - /documentation/rest/services/show.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET services/:id</h1><p>Get details about an existing service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Include extra information in the response. Possible values are <code>escalation_policy</code> (for inline Escalation Policy) and <code>email_filters</code> (for inline <a href="/documentation/rest/services/email_filters/">Email Filters</a>).
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PF9KMXH&quot;,&#x000A;    &quot;name&quot;: &quot;default&quot;,&#x000A;    &quot;service_url&quot;: &quot;/services/PF9KMXH&quot;,&#x000A;    &quot;service_key&quot;: &quot;amazing2@acme.pagerduty.com&quot;,&#x000A;    &quot;auto_resolve_timeout&quot;: null,&#x000A;    &quot;acknowledgement_timeout&quot;: null,&#x000A;    &quot;created_at&quot;: &quot;2012-08-15T20:15:52-04:00&quot;,&#x000A;    &quot;status&quot;: &quot;active&quot;,&#x000A;    &quot;last_incident_timestamp&quot;: &quot;2012-09-12T17:57:06-04:00&quot;,&#x000A;    &quot;email_incident_creation&quot;: &quot;on_new_email_subject&quot;,&#x000A;    &quot;incident_counts&quot;: {&#x000A;      &quot;triggered&quot;: 0,&#x000A;      &quot;acknowledged&quot;: 0,&#x000A;      &quot;resolved&quot;: 4,&#x000A;      &quot;total&quot;: 4&#x000A;    },&#x000A;    &quot;email_filter_mode&quot;: &quot;or-rules-email&quot;,&#x000A;    &quot;type&quot;: &quot;generic_email&quot;,&#x000A;    &quot;description&quot;: &quot;service default&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET services/:id
+  </h1>
+  <p>
+    Get details about an existing service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Include extra information in the response. Possible values are <code>escalation_policy</code> (for inline Escalation Policy) and <code>email_filters</code> (for inline <a href="/documentation/rest/services/email_filters/">Email Filters</a>).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "service": {
+    "id": "PF9KMXH",
+    "name": "default",
+    "service_url": "/services/PF9KMXH",
+    "service_key": "amazing2@acme.pagerduty.com",
+    "auto_resolve_timeout": null,
+    "acknowledgement_timeout": null,
+    "created_at": "2012-08-15T20:15:52-04:00",
+    "status": "active",
+    "last_incident_timestamp": "2012-09-12T17:57:06-04:00",
+    "email_incident_creation": "on_new_email_subject",
+    "incident_counts": {
+      "triggered": 0,
+      "acknowledged": 0,
+      "resolved": 4,
+      "total": 4
+    },
+    "email_filter_mode": "or-rules-email",
+    "type": "generic_email",
+    "description": "service default"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/services/update.html
+++ b/source/documentation/rest/services/update.html
@@ -2,31 +2,273 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/services">Services</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/services">Services</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT services/:id</h1><p>Update an existing service.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the service.
-</td></tr><tr><td>description</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>A description for the service. 1024 character maximum.
-</td></tr><tr><td>escalation_policy_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The id of the escalation policy to be used by this service.
-</td></tr><tr><td>acknowledgement_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td><p>The duration in seconds before an incidents acknowledged in this service become triggered again.</p>
-</td></tr><tr><td>auto_resolve_timeout</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td><p>The duration in seconds before a triggered incident auto-resolves itself.</p>
-</td></tr><tr><td>severity_filter</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Specifies what severity levels will create a new open incident.
-<p>For Keynote it can be one of:</p>
-<ul>
-<li><code>critical</code> Incidents are created when an alarm enters the Critical state</li>
-<li><code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states</li>
-</ul>
-For SQL Monitor it can be one of:
-<ul>
-<li><code>on_any</code> Incidents are created for alerts of any severity</li>
-<li><code>on_high</code> Incidents are created for alerts with high severity</li>
-<li><code>on_medium_high</code> Incidents are created for with high or medium severity</li>
-</ul>
-</td></tr></tbody></table></div><h4>Email specific settings</h4>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>service_key</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td><p>The service key for the service.</p>
-<p>Do not specify the domain. e.g. <code>my-service</code> rather than <code>my-service@my-subdomain.pagerduty.com</code></p>
-</td></tr><tr><td>email_incident_creation</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>One of <code>only-if-no-open-incidents</code>, <code>on-new-email-subject</code> or <code>on-new-email</code>.
-Defaults to <code>on-new-email</code>.
-</td></tr></tbody></table></div><h3>Example: Generic Email Service</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"service":{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>My New Name</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>Brand New Description</span>","escalation_policy_id":"<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBIS5NX</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;service&quot;: {&#x000A;    &quot;id&quot;: &quot;PBIS5NX&quot;,&#x000A;    &quot;name&quot;: &quot;My New Name&quot;,&#x000A;    &quot;service_url&quot;: &quot;/services/PBIS5NX&quot;,&#x000A;    &quot;service_key&quot;: &quot;7b68a2c011c20130a61638f6b11a5d17&quot;,&#x000A;    &quot;auto_resolve_timeout&quot;: 57600,&#x000A;    &quot;acknowledgement_timeout&quot;: 1800,&#x000A;    &quot;created_at&quot;: &quot;2012-11-15T21:23:07-05:00&quot;,&#x000A;    &quot;status&quot;: &quot;active&quot;,&#x000A;    &quot;last_incident_timestamp&quot;: null,&#x000A;    &quot;email_incident_creation&quot;: null,&#x000A;    &quot;incident_counts&quot;: {&#x000A;      &quot;triggered&quot;: 0,&#x000A;      &quot;acknowledged&quot;: 0,&#x000A;      &quot;resolved&quot;: 0,&#x000A;      &quot;total&quot;: 0&#x000A;    },&#x000A;    &quot;email_filter_mode&quot;: &quot;all-email&quot;,&#x000A;    &quot;type&quot;: &quot;generic_events_api&quot;,&#x000A;    &quot;description&quot;: &quot;Brand New Description&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT services/:id
+  </h1>
+  <p>
+    Update an existing service.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/services/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A description for the service. 1024 character maximum.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            escalation_policy_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The id of the escalation policy to be used by this service.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            acknowledgement_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The duration in seconds before an incidents acknowledged in this service become triggered again.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            auto_resolve_timeout
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The duration in seconds before a triggered incident auto-resolves itself.
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            severity_filter
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Specifies what severity levels will create a new open incident.
+            <p>
+              For Keynote it can be one of:
+            </p>
+            <ul>
+              <li>
+                <code>critical</code> Incidents are created when an alarm enters the Critical state
+              </li>
+              <li>
+                <code>critical_or_warning</code> Incidents are created when an alarm enters the Critical OR Warning states
+              </li>
+            </ul>For SQL Monitor it can be one of:
+            <ul>
+              <li>
+                <code>on_any</code> Incidents are created for alerts of any severity
+              </li>
+              <li>
+                <code>on_high</code> Incidents are created for alerts with high severity
+              </li>
+              <li>
+                <code>on_medium_high</code> Incidents are created for with high or medium severity
+              </li>
+            </ul>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h4>
+    Email specific settings
+  </h4>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            service_key
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            <p>
+              The service key for the service.
+            </p>
+            <p>
+              Do not specify the domain. e.g. <code>my-service</code> rather than <code>my-service@my-subdomain.pagerduty.com</code>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email_incident_creation
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            One of <code>only-if-no-open-incidents</code>, <code>on-new-email-subject</code> or <code>on-new-email</code>. Defaults to <code>on-new-email</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example: Generic Email Service
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"service":{"name":"<span class='curl_params-name contenteditable' contenteditable='true'>My New Name</span>","description":"<span class='curl_params-description contenteditable' contenteditable='true'>Brand New Description</span>","escalation_policy_id":"<span class='curl_params-escalation_policy_id contenteditable' contenteditable='true'>PIJ90N7</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/services/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBIS5NX</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "service": {
+    "id": "PBIS5NX",
+    "name": "My New Name",
+    "service_url": "/services/PBIS5NX",
+    "service_key": "7b68a2c011c20130a61638f6b11a5d17",
+    "auto_resolve_timeout": 57600,
+    "acknowledgement_timeout": 1800,
+    "created_at": "2012-11-15T21:23:07-05:00",
+    "status": "active",
+    "last_incident_timestamp": null,
+    "email_incident_creation": null,
+    "incident_counts": {
+      "triggered": 0,
+      "acknowledged": 0,
+      "resolved": 0,
+      "total": 0
+    },
+    "email_filter_mode": "all-email",
+    "type": "generic_events_api",
+    "description": "Brand New Description"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/teams/create.html
+++ b/source/documentation/rest/teams/create.html
@@ -4,65 +4,110 @@ layout: main
 permalink: /documentation/rest/teams/create/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>
-        <a href="/documentation/rest/teams">Teams</a>
-    </li>
+  </li>
+  <li>
+    <a href="/documentation/rest/teams">Teams</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>Create</li>
-</ul><div class="section">
-    <h1 class="title">POST teams</h1>
-    <p>Creates a new team.</p>
-    <h3>Resource URL</h3>
-    <div class="prism action-url language-bash">
-        <pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams</pre>
-    </div>
-    <h3>Parameters</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Required</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>name</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>Yes</td>
-                    <td>The name of the team
-                      </td>
-                </tr>
-                <tr>
-                    <td>description</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>No</td>
-                    <td>A description of the team
-                      </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Example</h3>
-    <h3>Create a team</h3>
+  </li>
+  <li>Create
+  </li>
+</ul>
+<div class="section">
+  <h1 class="title">
+    POST teams
+  </h1>
+  <p>
+    Creates a new team.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
     <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the team
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A description of the team
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Create a team
+  </h3>
+  <pre>
         <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
     -d '{"name":"<span class="curl_params-name contenteditable" contenteditable="true">A Mob of Emus</span>"}' \
     "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/teams"</code>
-    </pre>
-    <p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p>
-    <div class="clearfix"></div>
-    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-    <div class="response">
-        <pre>
+    
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
             <code class="language-javascript prettyprint linenums">
 {
   "team": {
@@ -72,6 +117,7 @@ permalink: /documentation/rest/teams/create/
   }
 }
 </code>
-        </pre>
-    </div>
+        
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/teams/delete.html
+++ b/source/documentation/rest/teams/delete.html
@@ -4,22 +4,52 @@ layout: main
 permalink: /documentation/rest/teams/delete/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>
-        <a href="/documentation/rest/teams">Teams</a>
-    </li>
+  </li>
+  <li>
+    <a href="/documentation/rest/teams">Teams</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>Delete</li>
-</ul><h1 class="title">DELETE teams/:id</h1><p>Deletes an existing team</p><h3>Resource URL</h3><div class="prism action-url language-bash">
-    <pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span></pre>
-</div><h3>Example</h3><pre>
+  </li>
+  <li>Delete
+  </li>
+</ul>
+<h1 class="title">
+  DELETE teams/:id
+</h1>
+<p>
+  Deletes an existing team
+</p>
+<h3>
+  Resource URL
+</h3>
+<div class="prism action-url language-bash">
+  <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+</div>
+<h3>
+  Example
+</h3>
+<pre>
     <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
     "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/teams/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
-</pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response">
-    <pre>
-        <code class="language-javascript prettyprint linenums"></code>
-    </pre>
+</pre>
+<p class="content-type-warning clearfix">
+  Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+</p>
+<div class="clearfix"></div>
+<h4>
+  Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+</h4>
+<div class="response">
+  <pre>
+        
+    
+</pre>
 </div>

--- a/source/documentation/rest/teams/index.html
+++ b/source/documentation/rest/teams/index.html
@@ -4,50 +4,74 @@ layout: main
 permalink: /documentation/rest/teams/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>Teams</li>
-</ul><div class="section">
-    <h1 class="title">Teams API</h1>
-    <table class="table action_index">
-        <caption>This API lets you access and manipulate teams.</caption>
-        <thead>
-            <th>Resource</th>
-            <th>Description</th>
-        </thead>
-        <tbody>
-            <tr>
-                <td>
-                    <a href="/documentation/rest/teams/list">GET teams</a>
-                </td>
-                <td>List existing teams.</td>
-            </tr>
-            <tr>
-                <td>
-                    <a href="/documentation/rest/teams/create">POST teams</a>
-                </td>
-                <td>Create a new team.</td>
-            </tr>
-            <tr>
-                <td>
-                    <a href="/documentation/rest/teams/show">GET teams/:id</a>
-                </td>
-                <td>Show detailed information about a team</td>
-            </tr>
-            <tr>
-                <td>
-                    <a href="/documentation/rest/teams/update">PUT teams/:id</a>
-                </td>
-                <td>Update a team.</td>
-            </tr>
-            <tr>
-                <td>
-                    <a href="/documentation/rest/teams/delete">DELETE teams/:id</a>
-                </td>
-                <td>Delete a team.</td>
-            </tr>
-        </tbody>
-    </table>
+  </li>
+  <li>Teams
+  </li>
+</ul>
+<div class="section">
+  <h1 class="title">
+    Teams API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      This API lets you access and manipulate teams.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/teams/list">GET teams</a>
+        </td>
+        <td>
+          List existing teams.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/teams/create">POST teams</a>
+        </td>
+        <td>
+          Create a new team.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/teams/show">GET teams/:id</a>
+        </td>
+        <td>
+          Show detailed information about a team
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/teams/update">PUT teams/:id</a>
+        </td>
+        <td>
+          Update a team.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/teams/delete">DELETE teams/:id</a>
+        </td>
+        <td>
+          Delete a team.
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>

--- a/source/documentation/rest/teams/list.html
+++ b/source/documentation/rest/teams/list.html
@@ -4,112 +4,186 @@ layout: main
 permalink: /documentation/rest/teams/list/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>
-        <a href="/documentation/rest/teams">Teams</a>
-    </li>
+  </li>
+  <li>
+    <a href="/documentation/rest/teams">Teams</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>List</li>
-</ul><div class="section">
-    <h1 class="title">GET teams</h1>
-    <p>List all the teams</p>
-    <h3>Resource URL</h3>
-    <div class="prism action-url language-bash">
-        <pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams</pre>
-    </div>
-    <h3>Parameters</h3>
-    <div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Required</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>query</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>No</td>
-                    <td>Filters the result, showing only the teams whose names match the query.
-                      </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Response Fields</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>teams</td>
-                    <td>
-                        <a href="/documentation/rest/types#array">Array</a>
-                    </td>
-                    <td>The collection of team objects returned by the query. Fields detailed below.
-                      </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Team Response Fields</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>id</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The ID of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>name</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The name of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>description</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>A description of the team.
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Example</h3>
-    <h3>Get all teams</h3>
+  </li>
+  <li>List
+  </li>
+</ul>
+<div class="section">
+  <h1 class="title">
+    GET teams
+  </h1>
+  <p>
+    List all the teams
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
     <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the teams whose names match the query.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            teams
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            The collection of team objects returned by the query. Fields detailed below.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Team Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A description of the team.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get all teams
+  </h3>
+  <pre>
         <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
     "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/teams"</code>
-    </pre>
-    <p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p>
-    <div class="clearfix"></div>
-    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-    <div class="response">
-        <pre>
+    
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
             <code class="language-javascript prettyprint linenums">
 {
   "teams": [
@@ -129,6 +203,7 @@ permalink: /documentation/rest/teams/list/
   "total": 2
 }
 </code>
-        </pre>
-    </div>
+        
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/teams/show.html
+++ b/source/documentation/rest/teams/show.html
@@ -4,69 +4,111 @@ layout: main
 permalink: /documentation/rest/teams/show/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>
-        <a href="/documentation/rest/teams">Teams</a>
-    </li>
+  </li>
+  <li>
+    <a href="/documentation/rest/teams">Teams</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>Show</li>
-</ul><div class="section">
-    <h1 class="title">GET teams/:id</h1>
-    <p>Get information about an existing team</p>
-    <h3>Resource URL</h3>
-    <div class="prism action-url language-bash">
-        <pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span></pre>
-    </div>
-    <h3>Team Response Fields</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>id</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The ID of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>name</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The name of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>description</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>A description of the team.
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Example</h3>
-    <h3>Get a team</h3>
+  </li>
+  <li>Show
+  </li>
+</ul>
+<div class="section">
+  <h1 class="title">
+    GET teams/:id
+  </h1>
+  <p>
+    Get information about an existing team
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
     <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Team Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A description of the team.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Get a team
+  </h3>
+  <pre>
         <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
     "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/teams/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBAZLIU</span>"</code>
-    </pre>
-    <p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p>
-    <div class="clearfix"></div>
-    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-    <div class="response">
-        <pre>
+    
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
 <code class="language-javascript prettyprint linenums">
 {
   "team": {
@@ -76,6 +118,7 @@ permalink: /documentation/rest/teams/show/
   }
 }
 </code>
-        </pre>
-    </div>
+        
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/teams/update.html
+++ b/source/documentation/rest/teams/update.html
@@ -4,101 +4,165 @@ layout: main
 permalink: /documentation/rest/teams/update/
 ---
 <ul class="breadcrumb">
-    <li>
-        <a href="/documentation/rest">REST API</a>
-    </li>
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>
-        <a href="/documentation/rest/teams">Teams</a>
-    </li>
+  </li>
+  <li>
+    <a href="/documentation/rest/teams">Teams</a>
+  </li>
+  <li style="list-style: none">
     <span class="divider">/</span>
-    <li>Update</li>
-</ul><div class="section">
-    <h1 class="title">PUT teams/:id</h1>
-    <p>Updates an existing team.</p>
-    <h3>Resource URL</h3>
-    <div class="prism action-url language-bash">
-        <pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span></pre>
-    </div>
-    <h3>Parameters</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Required</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>name</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>No</td>
-                    <td>The name of the team.
-                      </td>
-                </tr>
-                <tr>
-                    <td>description</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>No</td>
-                    <td>A description of the team.
-                      </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Team Response Fields</h3>
-    <div class="table-container">
-        <table class="table table-striped">
-            <thead>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Description</th>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>id</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The ID of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>name</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>The name of the team.
-                    </td>
-                </tr>
-                <tr>
-                    <td>description</td>
-                    <td>
-                        <a href="/documentation/rest/types#string">String</a>
-                    </td>
-                    <td>A description of the team.
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <h3>Example</h3>
-    <h3>Update a team</h3>
+  </li>
+  <li>Update
+  </li>
+</ul>
+<div class="section">
+  <h1 class="title">
+    PUT teams/:id
+  </h1>
+  <p>
+    Updates an existing team.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
     <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">subdomain</span>.pagerduty.com/api/v1/teams/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A description of the team.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Team Response Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The ID of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the team.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            description
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            A description of the team.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <h3>
+    Update a team
+  </h3>
+  <pre>
         <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
     -d '{"name":"<span class="curl_params-name contenteditable" contenteditable="true">A Barrel of Monkeys</span>"}' \
     "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/teams/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PBAZLIU</span>"</code>
-    </pre>
-    <p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p>
-    <div class="clearfix"></div>
-    <h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4>
-    <div class="response">
-        <pre>
+    
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
             <code class="language-javascript prettyprint linenums">
 {
   team: {
@@ -108,6 +172,7 @@ permalink: /documentation/rest/teams/update/
   }
 }
 </code>
-        </pre>
-    </div>
+        
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/types.html
+++ b/source/documentation/rest/types.html
@@ -5,65 +5,115 @@ permalink: /documentation/rest/types/
 redirect_from:
   - /documentation/rest/types.html
 ---
-                  <ul class="breadcrumb">
-                    <li><a href="/documentation/rest">REST API</a></li>
-                    <span class="divider">/</span>
-                    <li>Types</li>
-                  </ul>
-                  <div class='section'>
-                    <title></title>
-                    <h1 class="title">Types</h1>
-                    <a name='datetime'></a>
-                    <h2>Date and Time</h2>
-                    <p>All dates and times should be represented in the <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> date/time format. The time element is optional.</p>
-                    <p>Example dates in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format:</p>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Date and Time</th>
-                          <th>ISO 8601 Representation</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>May 6th, 2011 at 5pm UTC</td>
-                            <td>2011-05-06T17:00Z</td>
-                          </tr>
-                          <tr>
-                            <td>May 6th, 2011 at 3:30am PDT</td>
-                            <td>2011-05-06T03:30-07</td>
-                          </tr>
-                          <tr>
-                            <td>May 6th, 2011 at midnight (time is optional)</td>
-                            <td>2011-05-06</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <a name='boolean'></a>
-                    <h2>Boolean Values</h2>
-                    <p>The following values can be used to represent true and false. These values are not case sensitive.</p>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Value</th>
-                          <th>Acceptable String Representation</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>true</td>
-                            <td>1, true</td>
-                          </tr>
-                          <tr>
-                            <td>false</td>
-                            <td>0, false</td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <a name='timezone'></a>
-                    <h2>Time Zones</h2>
-                    <p>One of the following strings:
-<pre class='language-bash'><code>Abu Dhabi
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Types
+  </li>
+</ul>
+<div class='section'>
+  <h1 class="title">
+    Types
+  </h1><a name='datetime' id="datetime"></a>
+  <h2>
+    Date and Time
+  </h2>
+  <p>
+    All dates and times should be represented in the <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> date/time format. The time element is optional.
+  </p>
+  <p>
+    Example dates in <a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a> format:
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Date and Time
+          </th>
+          <th>
+            ISO 8601 Representation
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            May 6th, 2011 at 5pm UTC
+          </td>
+          <td>
+            2011-05-06T17:00Z
+          </td>
+        </tr>
+        <tr>
+          <td>
+            May 6th, 2011 at 3:30am PDT
+          </td>
+          <td>
+            2011-05-06T03:30-07
+          </td>
+        </tr>
+        <tr>
+          <td>
+            May 6th, 2011 at midnight (time is optional)
+          </td>
+          <td>
+            2011-05-06
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div><a name='boolean' id="boolean"></a>
+  <h2>
+    Boolean Values
+  </h2>
+  <p>
+    The following values can be used to represent true and false. These values are not case sensitive.
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Value
+          </th>
+          <th>
+            Acceptable String Representation
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            true
+          </td>
+          <td>
+            1, true
+          </td>
+        </tr>
+        <tr>
+          <td>
+            false
+          </td>
+          <td>
+            0, false
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div><a name='timezone' id="timezone"></a>
+  <h2>
+    Time Zones
+  </h2>
+  <p>
+    One of the following strings:
+  </p>
+  <pre class='language-bash'>
+<code>Abu Dhabi
 Adelaide
 Alaska
 Almaty
@@ -207,36 +257,65 @@ Wellington
 West Central Africa
 Yakutsk
 Yerevan
-Zagreb</code></pre></p>
-                    <a name='object'></a>
-                    <h2>Object</h2>
-                    <p>Object types are a JSON object.</p>
-                    <a name='array'></a>
-                    <h2>Array</h2>
-                    <p>Array types are used to represent a list of values.</p>
-                    <p>Example array values for the <code>include</code> parameter on a <code>GET</code> request:</p>
-                    <div class="table-container">
-                      <table class="table table-striped">
-                        <thead>
-                          <th>Values</th>
-                          <th>Query String Representation</th>
-                        </thead>
-                        <tbody>
-                          <tr>
-                            <td>contact_methods</td>
-                            <td><code>include[]=contact_methods</code></td>
-                          </tr>
-                          <tr>
-                            <td>contact_methods, notification_rules</td>
-                            <td><code>include[]=contact_methods&amp;include[]=notification_rules</code></td>
-                          </tr>
-                        </tbody>
-                      </table>
-                    </div>
-                    <a name='string'></a>
-                    <h2>String</h2>
-                    <p>String types are a sequence of UTF-8 characters.</p>
-                    <a name='int'></a>
-                    <h2>Integer</h2>
-                    <p>Integer types are a number without a fractional or decimal component.</p>
-                  </div>
+Zagreb</code>
+</pre><a name='object' id="object"></a>
+  <h2>
+    Object
+  </h2>
+  <p>
+    Object types are a JSON object.
+  </p><a name='array' id="array"></a>
+  <h2>
+    Array
+  </h2>
+  <p>
+    Array types are used to represent a list of values.
+  </p>
+  <p>
+    Example array values for the <code>include</code> parameter on a <code>GET</code> request:
+  </p>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Values
+          </th>
+          <th>
+            Query String Representation
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            contact_methods
+          </td>
+          <td>
+            <code>include[]=contact_methods</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            contact_methods, notification_rules
+          </td>
+          <td>
+            <code>include[]=contact_methods&amp;include[]=notification_rules</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div><a name='string' id="string"></a>
+  <h2>
+    String
+  </h2>
+  <p>
+    String types are a sequence of UTF-8 characters.
+  </p><a name='int' id="int"></a>
+  <h2>
+    Integer
+  </h2>
+  <p>
+    Integer types are a number without a fractional or decimal component.
+  </p>
+</div>

--- a/source/documentation/rest/users/contact_methods/create.html
+++ b/source/documentation/rest/users/contact_methods/create.html
@@ -2,22 +2,170 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/contact_methods/">Contact Methods</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/contact_methods/">Contact Methods</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST users/:user_id/contact_methods</h1><p>
-Create a new contact method for a given user. A contact method can be one of the following types:
-<code>SMS</code>, <code>email</code>, and <code>phone</code>.
-<code>push_notification</code> contact methods cannot be created using this API, they are added
-automatically during device registration.
-</p>
-<p>The contact info must be unique.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The type of the contact method. One of <code>SMS</code>, <code>email</code> or <code>phone</code>.
-</td></tr><tr><td>address</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the contact method. For <code>SMS</code> and <code>phone</code> it is the number,
-and for <code>email</code> it is the email address.
-</td></tr><tr><td>country_code</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The number code for your country. Not used for <code>email</code>. Defaults to 1.
-</td></tr><tr><td>label</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>A human friendly label for the contact method. (ie: "Home Phone", "Work Email", etc.)
-Defaults to the type of the contact method and the address (with country code for phone numbers).
-</td></tr><tr><td>send_short_email</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>Send an abbreviated email message instead of the standard email output. Useful for email-to-SMS
-gateways and email based pagers. Only valid for <code>email</code> contact methods. Defaults to false.
-</td></tr></tbody></table></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"contact_method":{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>phone</span>","address":"<span class='curl_params-address contenteditable' contenteditable='true'>5551112222</span>","label":"<span class='curl_params-label contenteditable' contenteditable='true'>Island Lair</span>","country_code":"<span class='curl_params-country_code contenteditable' contenteditable='true'>1</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;contact_method&quot;: {&#x000A;    &quot;id&quot;: &quot;PSDKM6U&quot;,&#x000A;    &quot;label&quot;: &quot;Island Lair&quot;,&#x000A;    &quot;address&quot;: &quot;5551112222&quot;,&#x000A;    &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;    &quot;type&quot;: &quot;phone&quot;,&#x000A;    &quot;country_code&quot;: 1,&#x000A;    &quot;phone_number&quot;: &quot;5551112222&quot;,&#x000A;    &quot;blacklisted&quot;: false&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST users/:user_id/contact_methods
+  </h1>
+  <p>
+    Create a new contact method for a given user. A contact method can be one of the following types: <code>SMS</code>, <code>email</code>, and <code>phone</code>. <code>push_notification</code> contact methods cannot be created using this API, they are added automatically during device registration.
+  </p>
+  <p>
+    The contact info must be unique.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The type of the contact method. One of <code>SMS</code>, <code>email</code> or <code>phone</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            address
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the contact method. For <code>SMS</code> and <code>phone</code> it is the number, and for <code>email</code> it is the email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            country_code
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The number code for your country. Not used for <code>email</code>. Defaults to 1.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            label
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A human friendly label for the contact method. (ie: "Home Phone", "Work Email", etc.) Defaults to the type of the contact method and the address (with country code for phone numbers).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            send_short_email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Send an abbreviated email message instead of the standard email output. Useful for email-to-SMS gateways and email based pagers. Only valid for <code>email</code> contact methods. Defaults to false.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"contact_method":{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>phone</span>","address":"<span class='curl_params-address contenteditable' contenteditable='true'>5551112222</span>","label":"<span class='curl_params-label contenteditable' contenteditable='true'>Island Lair</span>","country_code":"<span class='curl_params-country_code contenteditable' contenteditable='true'>1</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "contact_method": {
+    "id": "PSDKM6U",
+    "label": "Island Lair",
+    "address": "5551112222",
+    "user_id": "PPSFHH7",
+    "type": "phone",
+    "country_code": 1,
+    "phone_number": "5551112222",
+    "blacklisted": false
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/contact_methods/delete.html
+++ b/source/documentation/rest/users/contact_methods/delete.html
@@ -2,7 +2,56 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/contact_methods/">Contact Methods</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/contact_methods/">Contact Methods</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE users/:user_id/contact_methods/:id</h1><p>Remove a contact method and any corresponding notification rules.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE users/:user_id/contact_methods/:id
+  </h1>
+  <p>
+    Remove a contact method and any corresponding notification rules.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/users/contact_methods/index.html
+++ b/source/documentation/rest/users/contact_methods/index.html
@@ -2,12 +2,84 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Contact Methods</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Contact Methods
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Contact Methods API</h1>
-<p>
-Contact methods describe the various channels (phone numbers, SMS numbers and email addresses) used to contact a user when an <a href="/documentation/rest/incidents/">incident</a> is assigned to the user.
-</p>
-<table class="table action_index"><caption>Access and manipulate the contact methods for a user.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/users/contact_methods/list">GET users/:user_id/contact_methods</a></td><td>List existing contact methods for the specified user.</td></tr><tr><td><a href="/documentation/rest/users/contact_methods/show">GET users/:user_id/contact_methods/:id</a></td><td>Get details for a contact method.</td></tr><tr><td><a href="/documentation/rest/users/contact_methods/create">POST users/:user_id/contact_methods</a></td><td>Create a new contact method for the specified user.</td></tr><tr><td><a href="/documentation/rest/users/contact_methods/update">PUT users/:user_id/contact_methods/:id</a></td><td>Update an existing contact method.</td></tr><tr><td><a href="/documentation/rest/users/contact_methods/delete">DELETE users/:user_id/contact_methods/:id</a></td><td>Remove a contact method and any corresponding notification rules.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Contact Methods API
+  </h1>
+  <p>
+    Contact methods describe the various channels (phone numbers, SMS numbers and email addresses) used to contact a user when an <a href="/documentation/rest/incidents/">incident</a> is assigned to the user.
+  </p>
+  <table class="table action_index">
+    <caption>
+      Access and manipulate the contact methods for a user.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/contact_methods/list">GET users/:user_id/contact_methods</a>
+        </td>
+        <td>
+          List existing contact methods for the specified user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/contact_methods/show">GET users/:user_id/contact_methods/:id</a>
+        </td>
+        <td>
+          Get details for a contact method.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/contact_methods/create">POST users/:user_id/contact_methods</a>
+        </td>
+        <td>
+          Create a new contact method for the specified user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/contact_methods/update">PUT users/:user_id/contact_methods/:id</a>
+        </td>
+        <td>
+          Update an existing contact method.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/contact_methods/delete">DELETE users/:user_id/contact_methods/:id</a>
+        </td>
+        <td>
+          Remove a contact method and any corresponding notification rules.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/users/contact_methods/list.html
+++ b/source/documentation/rest/users/contact_methods/list.html
@@ -2,7 +2,93 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/contact_methods">Contact Methods</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/contact_methods">Contact Methods</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:user_id/contact_methods</h1><p>List existing contact methods for the specified user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods</pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;total&quot;: 3,&#x000A;  &quot;contact_methods&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PWQ8MIH&quot;,&#x000A;      &quot;label&quot;: &quot;Work&quot;,&#x000A;      &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;type&quot;: &quot;email&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;send_short_email&quot;: false&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P6W4C77&quot;,&#x000A;      &quot;label&quot;: &quot;Work&quot;,&#x000A;      &quot;address&quot;: &quot;5551234567&quot;,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;type&quot;: &quot;phone&quot;,&#x000A;      &quot;country_code&quot;: 1,&#x000A;      &quot;phone_number&quot;: &quot;5551234567&quot;,&#x000A;      &quot;blacklisted&quot;: false&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PK9SG1A&quot;,&#x000A;      &quot;label&quot;: &quot;Mobile&quot;,&#x000A;      &quot;address&quot;: &quot;5551234567&quot;,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;      &quot;type&quot;: &quot;SMS&quot;,&#x000A;      &quot;country_code&quot;: 1,&#x000A;      &quot;phone_number&quot;: &quot;5551234567&quot;,&#x000A;      &quot;blacklisted&quot;: false&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/:user_id/contact_methods
+  </h1>
+  <p>
+    List existing contact methods for the specified user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "total": 3,
+  "contact_methods": [
+    {
+      "id": "PWQ8MIH",
+      "label": "Work",
+      "address": "bob@acme.com",
+      "user_id": "PPSFHH7",
+      "type": "email",
+      "email": "bob@acme.com",
+      "send_short_email": false
+    },
+    {
+      "id": "P6W4C77",
+      "label": "Work",
+      "address": "5551234567",
+      "user_id": "PPSFHH7",
+      "type": "phone",
+      "country_code": 1,
+      "phone_number": "5551234567",
+      "blacklisted": false
+    },
+    {
+      "id": "PK9SG1A",
+      "label": "Mobile",
+      "address": "5551234567",
+      "user_id": "PPSFHH7",
+      "type": "SMS",
+      "country_code": 1,
+      "phone_number": "5551234567",
+      "blacklisted": false
+    }
+  ]
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/contact_methods/show.html
+++ b/source/documentation/rest/users/contact_methods/show.html
@@ -2,7 +2,71 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/contact_methods">Contact Methods</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/contact_methods">Contact Methods</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:user_id/contact_methods/:id</h1><p>Get details for a contact method.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;contact_method&quot;: {&#x000A;    &quot;id&quot;: &quot;P6W4C77&quot;,&#x000A;    &quot;label&quot;: &quot;Work&quot;,&#x000A;    &quot;address&quot;: &quot;5551234567&quot;,&#x000A;    &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;    &quot;type&quot;: &quot;phone&quot;,&#x000A;    &quot;country_code&quot;: 1,&#x000A;    &quot;phone_number&quot;: &quot;5551234567&quot;,&#x000A;    &quot;blacklisted&quot;: false&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/:user_id/contact_methods/:id
+  </h1>
+  <p>
+    Get details for a contact method.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "contact_method": {
+    "id": "P6W4C77",
+    "label": "Work",
+    "address": "5551234567",
+    "user_id": "PPSFHH7",
+    "type": "phone",
+    "country_code": 1,
+    "phone_number": "5551234567",
+    "blacklisted": false
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/contact_methods/update.html
+++ b/source/documentation/rest/users/contact_methods/update.html
@@ -2,17 +2,153 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/contact_methods">Contact Methods</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/contact_methods">Contact Methods</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT users/:user_id/contact_methods/:id</h1><p>
-Update an existing contact method of a given user. Note that you cannot change the type of an existing method.
-</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>address</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The id of the contact method. For <code>SMS</code> and <code>phone</code> it is the number,
-and for <code>email</code> it is the email address.
-</td></tr><tr><td>country_code</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>The number code for your country. Not used for <code>email</code>. Defaults to 1.
-</td></tr><tr><td>label</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>A human friendly label for the contact method. (ie: "Home Phone", "Work Email", etc.)
-Defaults to the type of the contact method and the address (with country code for phone numbers).
-</td></tr><tr><td>send_short_email</td><td><a href="/documentation/rest/types#boolean">Boolean</a></td><td>No</td><td>Send an abbreviated email message instead of the standard email output. Useful for email-to-SMS
-gateways and email based pagers. Only valid for <code>email</code> contact methods. Defaults to false.
-</td></tr></tbody></table></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"contact_method":{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>phone</span>","address":"<span class='curl_params-address contenteditable' contenteditable='true'>5558888888</span>","label":"<span class='curl_params-label contenteditable' contenteditable='true'>Island Lair</span>","country_code":"<span class='curl_params-country_code contenteditable' contenteditable='true'>1</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;contact_method&quot;: {&#x000A;    &quot;id&quot;: &quot;P6W4C77&quot;,&#x000A;    &quot;label&quot;: &quot;Island Lair&quot;,&#x000A;    &quot;address&quot;: &quot;5558888888&quot;,&#x000A;    &quot;user_id&quot;: &quot;PPSFHH7&quot;,&#x000A;    &quot;type&quot;: &quot;phone&quot;,&#x000A;    &quot;country_code&quot;: 1,&#x000A;    &quot;phone_number&quot;: &quot;5558888888&quot;,&#x000A;    &quot;blacklisted&quot;: false&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT users/:user_id/contact_methods/:id
+  </h1>
+  <p>
+    Update an existing contact method of a given user. Note that you cannot change the type of an existing method.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/contact_methods/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            address
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The id of the contact method. For <code>SMS</code> and <code>phone</code> it is the number, and for <code>email</code> it is the email address.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            country_code
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The number code for your country. Not used for <code>email</code>. Defaults to 1.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            label
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            A human friendly label for the contact method. (ie: "Home Phone", "Work Email", etc.) Defaults to the type of the contact method and the address (with country code for phone numbers).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            send_short_email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#boolean">Boolean</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Send an abbreviated email message instead of the standard email output. Useful for email-to-SMS gateways and email based pagers. Only valid for <code>email</code> contact methods. Defaults to false.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"contact_method":{"type":"<span class='curl_params-type contenteditable' contenteditable='true'>phone</span>","address":"<span class='curl_params-address contenteditable' contenteditable='true'>5558888888</span>","label":"<span class='curl_params-label contenteditable' contenteditable='true'>Island Lair</span>","country_code":"<span class='curl_params-country_code contenteditable' contenteditable='true'>1</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/contact_methods/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">P6W4C77</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "contact_method": {
+    "id": "P6W4C77",
+    "label": "Island Lair",
+    "address": "5558888888",
+    "user_id": "PPSFHH7",
+    "type": "phone",
+    "country_code": 1,
+    "phone_number": "5558888888",
+    "blacklisted": false
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/create.html
+++ b/source/documentation/rest/users/create.html
@@ -2,16 +2,183 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST users</h1><p>Create a new user for your account. An invite email will be sent asking the user to choose a password.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>role</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user's role. This can either be <code>admin</code>, <code>user</code>, or <code>limited_user</code> and defaults to <code>user</code> if not specificed
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The name of the user.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The email of the user. The newly created user will receive an email asking to confirm the subscription.
-</td></tr><tr><td>job_title</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The job title of the user.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>The time zone the user is in. If not specified, the time zone of the account making the API call will be used.
-</td></tr><tr><td>requester_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user id of the user creating the user. This is only needed if you are using token based authentication.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{    &#x000A;      "role": "<span class='curl_params-role contenteditable' contenteditable='true'>admin</span>",&#x000A;      "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Bart Simpson</span>",&#x000A;      "email": "<span class='curl_params-email contenteditable' contenteditable='true'>bart@example.com</span>",&#x000A;      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>",&#x000A;      "job_title": "<span class='curl_params-job_title contenteditable' contenteditable='true'>Developer</span>"&#x000A;    }' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;user&quot;: {&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;color&quot;: &quot;dark-slate-grey&quot;,&#x000A;    &quot;email&quot;: &quot;bart@example.com&quot;,&#x000A;    &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG&quot;,&#x000A;    &quot;user_url&quot;: &quot;/users/PIJ90N7&quot;,&#x000A;    &quot;invitation_sent&quot;: true,&#x000A;    &quot;role&quot;: &quot;admin&quot;,&#x000A;    &quot;name&quot;: &quot;Bart Simpson&quot;,&#x000A;    &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;    &quot;job_title&quot;: &quot;Developer&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST users
+  </h1>
+  <p>
+    Create a new user for your account. An invite email will be sent asking the user to choose a password.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            role
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user's role. This can either be <code>admin</code>, <code>user</code>, or <code>limited_user</code> and defaults to <code>user</code> if not specificed
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The name of the user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The email of the user. The newly created user will receive an email asking to confirm the subscription.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            job_title
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The job title of the user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The time zone the user is in. If not specified, the time zone of the account making the API call will be used.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            requester_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user id of the user creating the user. This is only needed if you are using token based authentication.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{    
+      "role": "<span class='curl_params-role contenteditable' contenteditable='true'>admin</span>",
+      "name": "<span class='curl_params-name contenteditable' contenteditable='true'>Bart Simpson</span>",
+      "email": "<span class='curl_params-email contenteditable' contenteditable='true'>bart@example.com</span>",
+      "requester_id": "<span class='curl_params-requester_id contenteditable' contenteditable='true'>PP1565R</span>",
+      "job_title": "<span class='curl_params-job_title contenteditable' contenteditable='true'>Developer</span>"
+    }' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "user": {
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "color": "dark-slate-grey",
+    "email": "bart@example.com",
+    "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG",
+    "user_url": "/users/PIJ90N7",
+    "invitation_sent": true,
+    "role": "admin",
+    "name": "Bart Simpson",
+    "id": "PIJ90N7",
+    "job_title": "Developer"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/delete.html
+++ b/source/documentation/rest/users/delete.html
@@ -2,20 +2,139 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE users/:id</h1><p>Remove an existing user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
-<h3>Conflict Errors</h3>
-<p>
-A user deletion can fail due to the user being a dependency of an escalation policy or schedule,
-or due to having an incident assigned to them. This will be indicated by a message in the <code>errors</code>
-array of the Error object and an additional field <code>conflicts</code> comprising an array of conflicts.
-</p>
-<pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;error&quot;: {&#x000A;    &quot;errors&quot;: [&#x000A;      &quot;The user cannot be deleted as they are currently in use&quot;&#x000A;    ],&#x000A;    &quot;conflicts&quot;: [&#x000A;      {&#x000A;        &quot;name&quot;: &quot;Primary Rotation&quot;,&#x000A;        &quot;type&quot;: &quot;schedule&quot;,&#x000A;        &quot;url&quot;: &quot;/services/PHL1X87&quot;,&#x000A;        &quot;id&quot;: &quot;PHL1X87&quot;&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre>
-<h3>Conflict Fields</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Description</th></thead><tbody><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>The name of the resource preventing the user from being deleted.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>The type of the resource. Can be one of [<code>schedule</code>, <code>ecalation_policy</code>, <code>incident</code>].
-</td></tr><tr><td>url</td><td><a href="/documentation/rest/types#string">String</a></td><td>The http URL at which the resource is located.
-</td></tr><tr><td>id</td><td><a href="/documentation/rest/types#string">String</a></td><td>The id of the resource
-</td></tr></tbody></table></div></div>
+  <h1 class="title">
+    DELETE users/:id
+  </h1>
+  <p>
+    Remove an existing user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
+  <h3>
+    Conflict Errors
+  </h3>
+  <p>
+    A user deletion can fail due to the user being a dependency of an escalation policy or schedule, or due to having an incident assigned to them. This will be indicated by a message in the <code>errors</code> array of the Error object and an additional field <code>conflicts</code> comprising an array of conflicts.
+  </p>
+  <pre>
+<code class="language-javascript prettyprint linenums">{
+  "error": {
+    "errors": [
+      "The user cannot be deleted as they are currently in use"
+    ],
+    "conflicts": [
+      {
+        "name": "Primary Rotation",
+        "type": "schedule",
+        "url": "/services/PHL1X87",
+        "id": "PHL1X87"
+      }
+    ]
+  }
+}</code>
+</pre>
+  <h3>
+    Conflict Fields
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The name of the resource preventing the user from being deleted.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The type of the resource. Can be one of [<code>schedule</code>, <code>ecalation_policy</code>, <code>incident</code>].
+          </td>
+        </tr>
+        <tr>
+          <td>
+            url
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The http URL at which the resource is located.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            The id of the resource
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/source/documentation/rest/users/index.html
+++ b/source/documentation/rest/users/index.html
@@ -2,14 +2,83 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Users</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Users
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Users API</h1>
-<table class="table action_index"><caption>Access and manipulate user data for your PagerDuty account. When a user is shown inlined in other resources, a deleted user will its html_url attribute set to null.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/users/list">GET users</a></td><td>List existing users.</td></tr>
-<tr><td><a href="/documentation/rest/users/show">GET users/:id</a></td><td>Get information about an existing user.</td></tr>
-<tr><td><a href="/documentation/rest/users/show_on_call">GET users/:id/on_call</a></td><td>Get information about an existing user with current on-call status.</td></tr>
-<tr><td><a href="/documentation/rest/users/create">POST users</a></td><td>Create a new user.</td></tr>
-<tr><td><a href="/documentation/rest/users/update">PUT users/:id</a></td><td>Update an existing user.</td></tr>
-<tr><td><a href="/documentation/rest/users/delete">DELETE users/:id</a></td><td>Remove an existing user.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Users API
+  </h1>
+  <table class="table action_index">
+    <caption>
+      Access and manipulate user data for your PagerDuty account. When a user is shown inlined in other resources, a deleted user will its html_url attribute set to null.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/list">GET users</a>
+        </td>
+        <td>
+          List existing users.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/show">GET users/:id</a>
+        </td>
+        <td>
+          Get information about an existing user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/show_on_call">GET users/:id/on_call</a>
+        </td>
+        <td>
+          Get information about an existing user with current on-call status.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/create">POST users</a>
+        </td>
+        <td>
+          Create a new user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/update">PUT users/:id</a>
+        </td>
+        <td>
+          Update an existing user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/delete">DELETE users/:id</a>
+        </td>
+        <td>
+          Remove an existing user.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/users/list.html
+++ b/source/documentation/rest/users/list.html
@@ -2,16 +2,142 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users</h1><p>List users of your PagerDuty account, optionally filtered by a search query.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the result, showing only the users whose names or email addresses match the query
-</td></tr><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. This API accepts <code>contact_methods</code>,
-and <code>notification_rules</code>.
-</td></tr></tbody></table></div><h2>Examples</h2>
-<h4>Get all users with that contain <code>john</code> in the name or email address</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>john</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;      &quot;name&quot;: &quot;John Smith&quot;,&#x000A;      &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;grey20&quot;,&#x000A;      &quot;role&quot;: &quot;user&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;      &quot;invitation_sent&quot;: true&#x000A;    }&#x000A;  ],&#x000A;  &quot;active_account_users&quot;: 1,&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;query&quot;: &quot;john&quot;,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
-<h4>Get all users with contact methods and notification rules</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code></pre>
+  <h1 class="title">
+    GET users
+  </h1>
+  <p>
+    List users of your PagerDuty account, optionally filtered by a search query.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the users whose names or email addresses match the query
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>contact_methods</code>, and <code>notification_rules</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h4>
+    Get all users with that contain <code>john</code> in the name or email address
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>john</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "id": "PP1565R",
+      "name": "John Smith",
+      "email": "john@example.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "grey20",
+      "role": "user",
+      "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+      "user_url": "/users/PP1565R",
+      "invitation_sent": true
+    }
+  ],
+  "active_account_users": 1,
+  "limit": 25,
+  "query": "john",
+  "offset": 0,
+  "total": 1
+}</code>
+</pre>
+  </div>
+  <h4>
+    Get all users with contact methods and notification rules
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users"</code>
+</pre>
 </div>

--- a/source/documentation/rest/users/notification_rules/create.html
+++ b/source/documentation/rest/users/notification_rules/create.html
@@ -2,10 +2,128 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/notification_rules">Notification Rules</a></li><span class="divider">/</span><li>Create</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/notification_rules">Notification Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Create
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">POST users/:user_id/notification_rules</h1><p>Create a new notification rule for the specified user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>Number of minutes it will take for the notification rule to be activated
-(from the time the incident is assigned to the owning user) and an alert be fired.
-</td></tr><tr><td>contact_method_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The id of the contact method
-</td></tr></tbody></table></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \&#x000A;    -d '{"notification_rule":{"contact_method_id":"<span class='curl_params-contact_method_id contenteditable' contenteditable='true'>PNGKILZ</span>","start_delay_in_minutes":4}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;notification_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PDHDWMP&quot;,&#x000A;    &quot;start_delay_in_minutes&quot;: 4,&#x000A;    &quot;contact_method&quot;: {&#x000A;      &quot;id&quot;: &quot;PNGKILZ&quot;,&#x000A;      &quot;label&quot;: &quot;Work&quot;,&#x000A;      &quot;type&quot;: &quot;email&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;send_short_email&quot;: false,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    POST users/:user_id/notification_rules
+  </h1>
+  <p>
+    Create a new notification rule for the specified user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+POST https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            start_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Number of minutes it will take for the notification rule to be activated (from the time the incident is assigned to the owning user) and an alert be fired.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            contact_method_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The id of the contact method
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
+    -d '{"notification_rule":{"contact_method_id":"<span class='curl_params-contact_method_id contenteditable' contenteditable='true'>PNGKILZ</span>","start_delay_in_minutes":4}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 201 Created <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "notification_rule": {
+    "id": "PDHDWMP",
+    "start_delay_in_minutes": 4,
+    "contact_method": {
+      "id": "PNGKILZ",
+      "label": "Work",
+      "type": "email",
+      "email": "bob@acme.com",
+      "address": "bob@acme.com",
+      "send_short_email": false,
+      "user_id": "PPSFHH7"
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/notification_rules/delete.html
+++ b/source/documentation/rest/users/notification_rules/delete.html
@@ -2,7 +2,56 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/notification_rules">Notification Rules</a></li><span class="divider">/</span><li>Delete</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/notification_rules">Notification Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Delete
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">DELETE users/:user_id/notification_rules/:id</h1><p>Remove a notification rule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums"></code></pre></div>
+  <h1 class="title">
+    DELETE users/:user_id/notification_rules/:id
+  </h1>
+  <p>
+    Remove a notification rule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+DELETE https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X DELETE \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 204 No Content <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response"></div>
 </div>

--- a/source/documentation/rest/users/notification_rules/index.html
+++ b/source/documentation/rest/users/notification_rules/index.html
@@ -2,14 +2,84 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Notification Rules</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Notification Rules
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Notification Rules API</h1>
-<p>
-When a user is assigned an <a href="/documentation/rest/incidents">incident</a>, the user's notification rules are used to
-determine which <a href="/documentation/rest/users/contact_methods/">contact method</a> will be used to alert the user and how
-long after the incident to do so.
-</p>
-<table class="table action_index"><caption>Access and manipulate the notification rules for a user.</caption><thead><th>Resource</th><th>Description</th></thead><tbody><tr><td><a href="/documentation/rest/users/notification_rules/list">GET users/:user_id/notification_rules</a></td><td>List existing notification rules for the specified user.</td></tr><tr><td><a href="/documentation/rest/users/notification_rules/show">GET users/:user_id/notification_rules/:id</a></td><td>Get details for a notification rule.</td></tr><tr><td><a href="/documentation/rest/users/notification_rules/create">POST users/:user_id/notification_rules</a></td><td>Create a new notification rule for the specified user.</td></tr><tr><td><a href="/documentation/rest/users/notification_rules/update">PUT users/:user_id/notification_rules/:id</a></td><td>Update an existing notification rule.</td></tr><tr><td><a href="/documentation/rest/users/notification_rules/delete">DELETE users/:user_id/notification_rules/:id</a></td><td>Remove a notification rule.</td></tr>
-</tbody></table></div>
+  <h1 class="title">
+    Notification Rules API
+  </h1>
+  <p>
+    When a user is assigned an <a href="/documentation/rest/incidents">incident</a>, the user's notification rules are used to determine which <a href="/documentation/rest/users/contact_methods/">contact method</a> will be used to alert the user and how long after the incident to do so.
+  </p>
+  <table class="table action_index">
+    <caption>
+      Access and manipulate the notification rules for a user.
+    </caption>
+    <thead>
+      <tr>
+        <th>
+          Resource
+        </th>
+        <th>
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/notification_rules/list">GET users/:user_id/notification_rules</a>
+        </td>
+        <td>
+          List existing notification rules for the specified user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/notification_rules/show">GET users/:user_id/notification_rules/:id</a>
+        </td>
+        <td>
+          Get details for a notification rule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/notification_rules/create">POST users/:user_id/notification_rules</a>
+        </td>
+        <td>
+          Create a new notification rule for the specified user.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/notification_rules/update">PUT users/:user_id/notification_rules/:id</a>
+        </td>
+        <td>
+          Update an existing notification rule.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <a href="/documentation/rest/users/notification_rules/delete">DELETE users/:user_id/notification_rules/:id</a>
+        </td>
+        <td>
+          Remove a notification rule.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/source/documentation/rest/users/notification_rules/list.html
+++ b/source/documentation/rest/users/notification_rules/list.html
@@ -2,7 +2,103 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/notification_rules">Notification Rules</a></li><span class="divider">/</span><li>List</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/notification_rules">Notification Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>List
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:user_id/notification_rules</h1><p>List existing notification rules for the specified user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules</pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;notification_rules&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PHU1XBC&quot;,&#x000A;      &quot;start_delay_in_minutes&quot;: 0,&#x000A;      &quot;contact_method&quot;: {&#x000A;        &quot;id&quot;: &quot;PNGKILZ&quot;,&#x000A;        &quot;label&quot;: &quot;Work&quot;,&#x000A;        &quot;type&quot;: &quot;email&quot;,&#x000A;        &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;        &quot;send_short_email&quot;: false,&#x000A;        &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PPRB3LC&quot;,&#x000A;      &quot;start_delay_in_minutes&quot;: 1,&#x000A;      &quot;contact_method&quot;: {&#x000A;        &quot;id&quot;: &quot;P1Q6FET&quot;,&#x000A;        &quot;label&quot;: &quot;Work&quot;,&#x000A;        &quot;type&quot;: &quot;phone&quot;,&#x000A;        &quot;country_code&quot;: 1,&#x000A;        &quot;phone_number&quot;: &quot;5551234567&quot;,&#x000A;        &quot;address&quot;: &quot;5551234567&quot;,&#x000A;        &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;P8FQ39P&quot;,&#x000A;      &quot;start_delay_in_minutes&quot;: 2,&#x000A;      &quot;contact_method&quot;: {&#x000A;        &quot;id&quot;: &quot;PK9SG1A&quot;,&#x000A;        &quot;label&quot;: &quot;Mobile&quot;,&#x000A;        &quot;type&quot;: &quot;SMS&quot;,&#x000A;        &quot;country_code&quot;: 1,&#x000A;        &quot;address&quot;: &quot;5551234567&quot;,&#x000A;        &quot;phone_number&quot;: &quot;5551234567&quot;,&#x000A;        &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;      }&#x000A;    }&#x000A;  ],&#x000A;  &quot;total&quot;: 3&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/:user_id/notification_rules
+  </h1>
+  <p>
+    List existing notification rules for the specified user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "notification_rules": [
+    {
+      "id": "PHU1XBC",
+      "start_delay_in_minutes": 0,
+      "contact_method": {
+        "id": "PNGKILZ",
+        "label": "Work",
+        "type": "email",
+        "email": "bob@acme.com",
+        "address": "bob@acme.com",
+        "send_short_email": false,
+        "user_id": "PPSFHH7"
+      }
+    },
+    {
+      "id": "PPRB3LC",
+      "start_delay_in_minutes": 1,
+      "contact_method": {
+        "id": "P1Q6FET",
+        "label": "Work",
+        "type": "phone",
+        "country_code": 1,
+        "phone_number": "5551234567",
+        "address": "5551234567",
+        "user_id": "PPSFHH7"
+      }
+    },
+    {
+      "id": "P8FQ39P",
+      "start_delay_in_minutes": 2,
+      "contact_method": {
+        "id": "PK9SG1A",
+        "label": "Mobile",
+        "type": "SMS",
+        "country_code": 1,
+        "address": "5551234567",
+        "phone_number": "5551234567",
+        "user_id": "PPSFHH7"
+      }
+    }
+  ],
+  "total": 3
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/notification_rules/show.html
+++ b/source/documentation/rest/users/notification_rules/show.html
@@ -2,7 +2,74 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/notification_rules">Notification Rules</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/notification_rules">Notification Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:user_id/notification_rules/:id</h1><p>Get details for a notification rule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;notification_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PHU1XBC&quot;,&#x000A;    &quot;start_delay_in_minutes&quot;: 0,&#x000A;    &quot;contact_method&quot;: {&#x000A;      &quot;id&quot;: &quot;PNGKILZ&quot;,&#x000A;      &quot;label&quot;: &quot;Work&quot;,&#x000A;      &quot;type&quot;: &quot;email&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;send_short_email&quot;: false,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/:user_id/notification_rules/:id
+  </h1>
+  <p>
+    Get details for a notification rule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "notification_rule": {
+    "id": "PHU1XBC",
+    "start_delay_in_minutes": 0,
+    "contact_method": {
+      "id": "PNGKILZ",
+      "label": "Work",
+      "type": "email",
+      "email": "bob@acme.com",
+      "address": "bob@acme.com",
+      "send_short_email": false,
+      "user_id": "PPSFHH7"
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/notification_rules/update.html
+++ b/source/documentation/rest/users/notification_rules/update.html
@@ -2,10 +2,128 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li><a href="/documentation/rest/users/notification_rules">Notification Rules</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users/notification_rules">Notification Rules</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT users/:user_id/notification_rules/:id</h1><p>Update an existing notification rule.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>start_delay_in_minutes</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>No</td><td>Number of minutes it will take for the notification rule to be activated
-(from the time the incident is assigned to the owning user) and an alert be fired.
-</td></tr><tr><td>contact_method_id</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The id of the contact method
-</td></tr></tbody></table></div><h3>Example</h3><pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"notification_rule":{"contact_method_id":"<span class='curl_params-contact_method_id contenteditable' contenteditable='true'>PNGKILZ</span>","start_delay_in_minutes":5}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div><h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;notification_rule&quot;: {&#x000A;    &quot;id&quot;: &quot;PHU1XBC&quot;,&#x000A;    &quot;start_delay_in_minutes&quot;: 5,&#x000A;    &quot;contact_method&quot;: {&#x000A;      &quot;id&quot;: &quot;PNGKILZ&quot;,&#x000A;      &quot;label&quot;: &quot;Work&quot;,&#x000A;      &quot;type&quot;: &quot;email&quot;,&#x000A;      &quot;email&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;address&quot;: &quot;bob@acme.com&quot;,&#x000A;      &quot;send_short_email&quot;: false,&#x000A;      &quot;user_id&quot;: &quot;PPSFHH7&quot;&#x000A;    }&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT users/:user_id/notification_rules/:id
+  </h1>
+  <p>
+    Update an existing notification rule.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:user_id</span>/notification_rules/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            start_delay_in_minutes
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Number of minutes it will take for the notification rule to be activated (from the time the incident is assigned to the owning user) and an alert be fired.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            contact_method_id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The id of the contact method
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"notification_rule":{"contact_method_id":"<span class='curl_params-contact_method_id contenteditable' contenteditable='true'>PNGKILZ</span>","start_delay_in_minutes":5}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-user_id user_id contenteditable" contenteditable="true">PPSFHH7</span>/notification_rules/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PHU1XBC</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "notification_rule": {
+    "id": "PHU1XBC",
+    "start_delay_in_minutes": 5,
+    "contact_method": {
+      "id": "PNGKILZ",
+      "label": "Work",
+      "type": "email",
+      "email": "bob@acme.com",
+      "address": "bob@acme.com",
+      "send_short_email": false,
+      "user_id": "PPSFHH7"
+    }
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/on_call.html
+++ b/source/documentation/rest/users/on_call.html
@@ -2,15 +2,156 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>On Call</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>On Call
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/on_call</h1><p>List currently on-call users of your PagerDuty account, optionally filtered by a search query.</p>
-<p>If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/on_call</pre></div><h3>Parameters</h3><div class="alert alert-warning">This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.</div><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>query</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>Filters the result, showing only the users whose names or email addresses match the query
-</td></tr><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. This API accepts <code>contact_methods</code>,
-and <code>notification_rules</code>.
-</td></tr></tbody></table></div><h2>Examples</h2>
-<h4>Get all on-call users that contain <code>john</code> in the name or email address.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>john</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/on_call"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;users&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;PP1565R&quot;,&#x000A;      &quot;name&quot;: &quot;John Smith&quot;,&#x000A;      &quot;email&quot;: &quot;john@example.com&quot;,&#x000A;      &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;      &quot;color&quot;: &quot;grey20&quot;,&#x000A;      &quot;role&quot;: &quot;user&quot;,&#x000A;      &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG&quot;,&#x000A;      &quot;user_url&quot;: &quot;/users/PP1565R&quot;,&#x000A;      &quot;invitation_sent&quot;: true,&#x000A;      &quot;on_call&quot;: [&#x000A;        {&#x000A;          &quot;level&quot;: 1,&#x000A;          &quot;start&quot;: &quot;2014-03-03T17:00:00Z&quot;,&#x000A;          &quot;end&quot;: &quot;2014-03-10T16:00:00Z&quot;,&#x000A;          &quot;escalation_policy&quot;: {&#x000A;            &quot;id&quot;: &quot;PNYVO74&quot;,&#x000A;            &quot;name&quot;: &quot;Operatations&quot;&#x000A;          }&#x000A;        },&#x000A;        {&#x000A;          &quot;level&quot;: 3,&#x000A;          &quot;start&quot;: null,&#x000A;          &quot;end&quot;: null,&#x000A;          &quot;escalation_policy&quot;: {&#x000A;            &quot;id&quot;: &quot;P838D3B&quot;,&#x000A;            &quot;name&quot;: &quot;Web Team&quot;&#x000A;          }&#x000A;        }&#x000A;      ]&#x000A;    }&#x000A;  ],&#x000A;  &quot;active_account_users&quot;: 1,&#x000A;  &quot;limit&quot;: 25,&#x000A;  &quot;query&quot;: &quot;john&quot;,&#x000A;  &quot;offset&quot;: 0,&#x000A;  &quot;total&quot;: 1&#x000A;}</code></pre></div>
+  <h1 class="title">
+    GET users/on_call
+  </h1>
+  <p>
+    List currently on-call users of your PagerDuty account, optionally filtered by a search query.
+  </p>
+  <p>
+    If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/on_call
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="alert alert-warning">
+    This action is paginated. See the <a href="/documentation/rest/pagination">pagination documentation</a> for details.
+  </div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            query
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Filters the result, showing only the users whose names or email addresses match the query
+          </td>
+        </tr>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>contact_methods</code>, and <code>notification_rules</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h2>
+    Examples
+  </h2>
+  <h4>
+    Get all on-call users that contain <code>john</code> in the name or email address.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "query=<span class='curl_params-query contenteditable' contenteditable='true'>john</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/on_call"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "users": [
+    {
+      "id": "PP1565R",
+      "name": "John Smith",
+      "email": "john@example.com",
+      "time_zone": "Eastern Time (US &amp; Canada)",
+      "color": "grey20",
+      "role": "user",
+      "avatar_url": "https://secure.gravatar.com/avatar/2e32280905f296791ed387cd0f61ec6b.png?d=mm&amp;r=PG",
+      "user_url": "/users/PP1565R",
+      "invitation_sent": true,
+      "on_call": [
+        {
+          "level": 1,
+          "start": "2014-03-03T17:00:00Z",
+          "end": "2014-03-10T16:00:00Z",
+          "escalation_policy": {
+            "id": "PNYVO74",
+            "name": "Operatations"
+          }
+        },
+        {
+          "level": 3,
+          "start": null,
+          "end": null,
+          "escalation_policy": {
+            "id": "P838D3B",
+            "name": "Web Team"
+          }
+        }
+      ]
+    }
+  ],
+  "active_account_users": 1,
+  "limit": 25,
+  "query": "john",
+  "offset": 0,
+  "total": 1
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/users/show.html
+++ b/source/documentation/rest/users/show.html
@@ -2,14 +2,118 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Show</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:id</h1><p>Get information about an existing user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. This API accepts <code>contact_methods</code>,
-and <code>notification_rules</code>.
-</td></tr></tbody></table></div><h4>Examples</h4>
-<h4>Get a single user</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;user&quot;: {&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;color&quot;: &quot;dark-slate-grey&quot;,&#x000A;    &quot;email&quot;: &quot;bart@example.com&quot;,&#x000A;    &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG&quot;,&#x000A;    &quot;user_url&quot;: &quot;/users/PIJ90N7&quot;,&#x000A;    &quot;invitation_sent&quot;: true,&#x000A;    &quot;role&quot;: &quot;admin&quot;,&#x000A;    &quot;name&quot;: &quot;Bart Simpson&quot;,&#x000A;    &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;    &quot;job_title&quot;: &quot;Developer&quot;&#x000A;  }&#x000A;}</code></pre></div>
-<h4>Get a single user with notification rules and contact methods</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/:id"</code></pre>
+  <h1 class="title">
+    GET users/:id
+  </h1>
+  <p>
+    Get information about an existing user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>contact_methods</code>, and <code>notification_rules</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h4>
+    Examples
+  </h4>
+  <h4>
+    Get a single user
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "user": {
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "color": "dark-slate-grey",
+    "email": "bart@example.com",
+    "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG",
+    "user_url": "/users/PIJ90N7",
+    "invitation_sent": true,
+    "role": "admin",
+    "name": "Bart Simpson",
+    "id": "PIJ90N7",
+    "job_title": "Developer"
+  }
+}</code>
+</pre>
+  </div>
+  <h4>
+    Get a single user with notification rules and contact methods
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/:id"</code>
+</pre>
 </div>

--- a/source/documentation/rest/users/show_on_call.html
+++ b/source/documentation/rest/users/show_on_call.html
@@ -2,16 +2,132 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Show On Call</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Show On Call
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">GET users/:id/on_call</h1><p>Get a user object with that user's current on-call status. If the on-call object is an empty array, the user is never on-call.</p>
-<p>If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.</p>
-<h3>Resource URL</h3><div class="prism action-url language-bash"><pre>GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span>/on_call</pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>include</td><td><a href="/documentation/rest/types#array">Array</a></td><td>No</td><td>Array of additional details to include. This API accepts <code>contact_methods</code>,
-and <code>notification_rules</code>.
-</td></tr></tbody></table></div><h4>Examples</h4>
-<h4>Get a single user with current on-call status.</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/on_call"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;user&quot;: {&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;color&quot;: &quot;dark-slate-grey&quot;,&#x000A;    &quot;email&quot;: &quot;bart@example.com&quot;,&#x000A;    &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG&quot;,&#x000A;    &quot;user_url&quot;: &quot;/users/PIJ90N7&quot;,&#x000A;    &quot;invitation_sent&quot;: true,&#x000A;    &quot;role&quot;: &quot;admin&quot;,&#x000A;    &quot;name&quot;: &quot;Bart Simpson&quot;,&#x000A;    &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;    &quot;job_title&quot;: &quot;Developer&quot;,&#x000A;    &quot;on_call&quot;: [&#x000A;      {&#x000A;        &quot;level&quot;: 1,&#x000A;        &quot;start&quot;: null,&#x000A;        &quot;end&quot;: null,&#x000A;        &quot;escalation_policy&quot;: {&#x000A;          &quot;id&quot;: &quot;PPSXMY3&quot;,&#x000A;          &quot;name&quot;: &quot;Operations&quot;&#x000A;        }&#x000A;      }&#x000A;    ]&#x000A;  }&#x000A;}</code></pre></div>
-<h4>Get a single user with notification rules and contact methods</h4>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \&#x000A;    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/:id/on_call"</code></pre>
+  <h1 class="title">
+    GET users/:id/on_call
+  </h1>
+  <p>
+    Get a user object with that user's current on-call status. If the on-call object is an empty array, the user is never on-call.
+  </p>
+  <p>
+    If the <code>start</code> and <code>end</code> of an on-call object are <code>null</code>, then the user is always on-call for an escalation policy level.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+GET https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span>/on_call
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            include
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Array of additional details to include. This API accepts <code>contact_methods</code>, and <code>notification_rules</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h4>
+    Examples
+  </h4>
+  <h4>
+    Get a single user with current on-call status.
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>/on_call"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "user": {
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "color": "dark-slate-grey",
+    "email": "bart@example.com",
+    "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG",
+    "user_url": "/users/PIJ90N7",
+    "invitation_sent": true,
+    "role": "admin",
+    "name": "Bart Simpson",
+    "id": "PIJ90N7",
+    "job_title": "Developer",
+    "on_call": [
+      {
+        "level": 1,
+        "start": null,
+        "end": null,
+        "escalation_policy": {
+          "id": "PPSXMY3",
+          "name": "Operations"
+        }
+      }
+    ]
+  }
+}</code>
+</pre>
+  </div>
+  <h4>
+    Get a single user with notification rules and contact methods
+  </h4>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X GET -G \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>contact_methods</span>" \
+    --data-urlencode "include[]=<span class='curl_params-include contenteditable' contenteditable='true'>notification_rules</span>" \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/:id/on_call"</code>
+</pre>
 </div>

--- a/source/documentation/rest/users/update.html
+++ b/source/documentation/rest/users/update.html
@@ -2,14 +2,163 @@
 title: PagerDuty Developer
 layout: main
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li><a href="/documentation/rest/users">Users</a></li><span class="divider">/</span><li>Update</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>
+    <a href="/documentation/rest/users">Users</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Update
+  </li>
+</ul>
 <div class='section'>
-<h1 class="title">PUT users/:id</h1><p>Update an existing user.</p><h3>Resource URL</h3><div class="prism action-url language-bash"><pre>PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span></pre></div><h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>role</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The user's role. This can either be <code>admin</code>, <code>user</code>, or <code>limited_user</code>.
-</td></tr><tr><td>name</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The name of the user.
-</td></tr><tr><td>email</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The email of the user.
-</td></tr><tr><td>job_title</td><td><a href="/documentation/rest/types#string">String</a></td><td>No</td><td>The job title of the user.
-</td></tr><tr><td>time_zone</td><td><a href="/documentation/rest/types#timezone">Time Zone</a></td><td>No</td><td>The time zone the user is in.
-</td></tr></tbody></table></div><h3>Example</h3>
-<pre><code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \&#x000A;    -d '{"user":{"role":"<span class='curl_params-role contenteditable' contenteditable='true'>admin</span>","name":"<span class='curl_params-name contenteditable' contenteditable='true'>Bart Simpson</span>","email":"<span class='curl_params-email contenteditable' contenteditable='true'>bart@example.com</span>","job_title":"<span class='curl_params-job_title contenteditable' contenteditable='true'>Developer</span>"}}' \&#x000A;    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code></pre><p class="content-type-warning clearfix">Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code></p><div class="clearfix"></div>
-<h4>Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"><i class="icon-question-sign"></i></a></span></h4><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;user&quot;: {&#x000A;    &quot;time_zone&quot;: &quot;Eastern Time (US &amp; Canada)&quot;,&#x000A;    &quot;color&quot;: &quot;dark-slate-grey&quot;,&#x000A;    &quot;email&quot;: &quot;bart@example.com&quot;,&#x000A;    &quot;avatar_url&quot;: &quot;https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG&quot;,&#x000A;    &quot;user_url&quot;: &quot;/users/PIJ90N7&quot;,&#x000A;    &quot;invitation_sent&quot;: true,&#x000A;    &quot;role&quot;: &quot;admin&quot;,&#x000A;    &quot;name&quot;: &quot;Bart Simpson&quot;,&#x000A;    &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;    &quot;job_title&quot;: &quot;Developer&quot;&#x000A;  }&#x000A;}</code></pre></div>
+  <h1 class="title">
+    PUT users/:id
+  </h1>
+  <p>
+    Update an existing user.
+  </p>
+  <h3>
+    Resource URL
+  </h3>
+  <div class="prism action-url language-bash">
+    <pre>
+PUT https://<span class="base_url contenteditable persist" contenteditable="true">&lt;subdomain&gt;</span>.pagerduty.com/api/v1/users/<span class="url_param contenteditable" contenteditable="true">:id</span>
+</pre>
+  </div>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            role
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The user's role. This can either be <code>admin</code>, <code>user</code>, or <code>limited_user</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            name
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The name of the user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            email
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The email of the user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            job_title
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The job title of the user.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            time_zone
+          </td>
+          <td>
+            <a href="/documentation/rest/types#timezone">Time Zone</a>
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            The time zone the user is in.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <h3>
+    Example
+  </h3>
+  <pre>
+<code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X PUT \
+    -d '{"user":{"role":"<span class='curl_params-role contenteditable' contenteditable='true'>admin</span>","name":"<span class='curl_params-name contenteditable' contenteditable='true'>Bart Simpson</span>","email":"<span class='curl_params-email contenteditable' contenteditable='true'>bart@example.com</span>","job_title":"<span class='curl_params-job_title contenteditable' contenteditable='true'>Developer</span>"}}' \
+    "https://<span class="base_url contenteditable persist" contenteditable="true">acme</span>.pagerduty.com/api/v1/users/<span class="sub_params_in_url-id id contenteditable" contenteditable="true">PIJ90N7</span>"</code>
+</pre>
+  <p class="content-type-warning clearfix">
+    Note: <code>Content-type</code> of the request <strong>must</strong> be <code>application/json</code>
+  </p>
+  <div class="clearfix"></div>
+  <h4>
+    Response <span class="response-status">Status: 200 OK <a href="/documentation/rest/errors#http_codes"></a></span>
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "user": {
+    "time_zone": "Eastern Time (US &amp; Canada)",
+    "color": "dark-slate-grey",
+    "email": "bart@example.com",
+    "avatar_url": "https://secure.gravatar.com/avatar/6e1b6fc29a03fc3c13756bd594e314f7.png?d=mm&amp;r=PG",
+    "user_url": "/users/PIJ90N7",
+    "invitation_sent": true,
+    "role": "admin",
+    "name": "Bart Simpson",
+    "id": "PIJ90N7",
+    "job_title": "Developer"
+  }
+}</code>
+</pre>
+  </div>
 </div>

--- a/source/documentation/rest/webhooks.html
+++ b/source/documentation/rest/webhooks.html
@@ -5,28 +5,273 @@ permalink: /documentation/rest/webhooks/
 redirect_from:
   - /documentation/rest/webhooks.html
 ---
-<ul class="breadcrumb"><li><a href="/documentation/rest">REST API</a></li><span class="divider">/</span><li>Webhooks</li></ul>
+<ul class="breadcrumb">
+  <li>
+    <a href="/documentation/rest">REST API</a>
+  </li>
+  <li style="list-style: none">
+    <span class="divider">/</span>
+  </li>
+  <li>Webhooks
+  </li>
+</ul>
 <div class='section'>
-<title></title>
-<h1 class="title">Webhooks API</h1>
-<p>Webhooks let you recieve HTTP callbacks when interesting events happen within your PagerDuty account. Details surrounding the interesting event will be sent via HTTP to a URL that you specify.</p>
-<p>PagerDuty currently supports incident-based webhooks. After adding a webhook URL to a PagerDuty service, the triggering of new incidents on that service will cause outgoing webhook messages to be sent to that URL. In addition, certain interesting changes to an incident's state will cause other types of incident webhook messages to be sent: Generally, any change to the <code>status</code> or <code>assigned_to_user</code> of an incident will cause an outgoing message to be sent.</p>
-<h4>The following incident webhook message types are supported:</h4>
-<div class="table-container"><table class="table table-striped"><thead><th>Type</th><th>Description</th></thead><tbody><tr><td>incident.trigger</td><td>Sent when an incident is newly created/triggered.</td></tr>
-<tr><td>incident.acknowledge</td><td>Sent when an incident has had its status changed from <code>triggered</code> to <code>acknowledged</code>.</td></tr>
-<tr><td>incident.unacknowledge</td><td>Sent when an incident is unacknowledged due to timeout.</td></tr>
-<tr><td>incident.resolve</td><td>Sent when an incident has been resolved.</td></tr>
-<tr><td>incident.assign</td><td>Sent when an incident has been manually reassigned to another user in a different escalation chain.</td></tr>
-<tr><td>incident.escalate</td><td>Sent when an incident has been escalated to another user in the same escalation chain.</td></tr>
-<tr><td>incident.delegate</td><td>Sent when an incident has been reassigned to another escalation chain.</td></tr>
-</tbody></table></div><p>NOTE: As new types of incident actions are supported, new incident webhook message types will be added.</p>
-<h3>Parameters</h3><div class="table-container"><table class="table table-striped"><thead><th>Name</th><th>Type</th><th>Required</th><th>Description</th></thead><tbody><tr><td>id</td><td><a href="/documentation/rest/types#int">Integer</a></td><td>Yes</td><td>Uniquely identifies this outgoing webhook message; can be used for idempotency when processing the messages.
-</td></tr><tr><td>type</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The webhook message type (see above list).
-</td></tr><tr><td>created_on</td><td><a href="/documentation/rest/types#datetime">Date</a></td><td>Yes</td><td>The date/time when the incident changed state.
-</td></tr><tr><td>data</td><td><a href="/documentation/rest/types#string">String</a></td><td>Yes</td><td>The incident details at the time of the state change. Incident details are formatted similarly to the results of the Incident API.
-</td></tr></tbody></table></div><p>NOTE: Outgoing messages are sent in an array. It is possible that multiple outgoing messages will be batched together and sent all at once from PagerDuty in a single outgoing webhook.</p>
-<h4>Sample Outbound Webhook Incident Payload (both a <code>trigger</code> and a <code>resolve</code> at once)</h4>
-<p><div class="response"><pre><code class="language-javascript prettyprint linenums">{&#x000A;  &quot;messages&quot;: [&#x000A;    {&#x000A;      &quot;id&quot;: &quot;bb8b8fe0-e8d5-11e2-9c1e-22000afd16cf&quot;,&#x000A;      &quot;created_on&quot;: &quot;2013-07-09T20:25:44Z&quot;,&#x000A;      &quot;type&quot;: &quot;incident.trigger&quot;,&#x000A;      &quot;data&quot;: {&#x000A;        &quot;incident&quot;: {&#x000A;          &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;          &quot;incident_number&quot;: 1,&#x000A;          &quot;created_on&quot;: &quot;2013-07-09T20:25:44Z&quot;,&#x000A;          &quot;status&quot;: &quot;triggered&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7&quot;,&#x000A;          &quot;incident_key&quot;: &quot;null&quot;,&#x000A;          &quot;service&quot;: {&#x000A;            &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;            &quot;name&quot;: &quot;service&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PBAZLIU&quot;&#x000A;          },&#x000A;          &quot;assigned_to_user&quot;: {&#x000A;            &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;            &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;            &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;&#x000A;          },&#x000A;          &quot;trigger_summary_data&quot;: {&#x000A;            &quot;subject&quot;: &quot;45645&quot;&#x000A;          },&#x000A;          &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7&quot;,&#x000A;          &quot;last_status_change_on&quot;: &quot;2013-07-09T20:25:44Z&quot;,&#x000A;          &quot;last_status_change_by&quot;: &quot;null&quot;&#x000A;        }&#x000A;      }&#x000A;    },&#x000A;    {&#x000A;      &quot;id&quot;: &quot;8a1d6420-e9c4-11e2-b33e-f23c91699516&quot;,&#x000A;      &quot;created_on&quot;: &quot;2013-07-09T20:25:45Z&quot;,&#x000A;      &quot;type&quot;: &quot;incident.resolve&quot;,&#x000A;      &quot;data&quot;: {&#x000A;        &quot;incident&quot;: {&#x000A;          &quot;id&quot;: &quot;PIJ90N7&quot;,&#x000A;          &quot;incident_number&quot;: 1,&#x000A;          &quot;created_on&quot;: &quot;2013-07-09T20:25:44Z&quot;,&#x000A;          &quot;status&quot;: &quot;resolved&quot;,&#x000A;          &quot;html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7&quot;,&#x000A;          &quot;incident_key&quot;: &quot;null&quot;,&#x000A;          &quot;service&quot;: {&#x000A;            &quot;id&quot;: &quot;PBAZLIU&quot;,&#x000A;            &quot;name&quot;: &quot;service&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/services/PBAZLIU&quot;&#x000A;          },&#x000A;          &quot;assigned_to_user&quot;: &quot;null&quot;,&#x000A;          &quot;resolved_by_user&quot;: {&#x000A;            &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;            &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;            &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;&#x000A;          },&#x000A;          &quot;trigger_summary_data&quot;: {&#x000A;            &quot;subject&quot;: &quot;45645&quot;&#x000A;          },&#x000A;          &quot;trigger_details_html_url&quot;: &quot;https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7&quot;,&#x000A;          &quot;last_status_change_on&quot;: &quot;2013-07-09T20:25:45Z&quot;,&#x000A;          &quot;last_status_change_by&quot;: {&#x000A;            &quot;id&quot;: &quot;PPI9KUT&quot;,&#x000A;            &quot;name&quot;: &quot;Alan Kay&quot;,&#x000A;            &quot;email&quot;: &quot;alan@pagerduty.com&quot;,&#x000A;            &quot;html_url&quot;: &quot;https://acme.pagerduty.com/users/PPI9KUT&quot;&#x000A;          }&#x000A;        }&#x000A;      }&#x000A;    }&#x000A;  ]&#x000A;}</code></pre></div></p>
-<h4>Troubleshooting</h4>
-<p>If you have any issues debugging your webhooks, you can use <a href="http://requestb.in/">RequestBin</a> to debug them.</p>
+  <h1 class="title">
+    Webhooks API
+  </h1>
+  <p>
+    Webhooks let you recieve HTTP callbacks when interesting events happen within your PagerDuty account. Details surrounding the interesting event will be sent via HTTP to a URL that you specify.
+  </p>
+  <p>
+    PagerDuty currently supports incident-based webhooks. After adding a webhook URL to a PagerDuty service, the triggering of new incidents on that service will cause outgoing webhook messages to be sent to that URL. In addition, certain interesting changes to an incident's state will cause other types of incident webhook messages to be sent: Generally, any change to the <code>status</code> or <code>assigned_to_user</code> of an incident will cause an outgoing message to be sent.
+  </p>
+  <h4>
+    The following incident webhook message types are supported:
+  </h4>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Type
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            incident.trigger
+          </td>
+          <td>
+            Sent when an incident is newly created/triggered.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.acknowledge
+          </td>
+          <td>
+            Sent when an incident has had its status changed from <code>triggered</code> to <code>acknowledged</code>.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.unacknowledge
+          </td>
+          <td>
+            Sent when an incident is unacknowledged due to timeout.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.resolve
+          </td>
+          <td>
+            Sent when an incident has been resolved.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.assign
+          </td>
+          <td>
+            Sent when an incident has been manually reassigned to another user in a different escalation chain.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.escalate
+          </td>
+          <td>
+            Sent when an incident has been escalated to another user in the same escalation chain.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            incident.delegate
+          </td>
+          <td>
+            Sent when an incident has been reassigned to another escalation chain.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p>
+    NOTE: As new types of incident actions are supported, new incident webhook message types will be added.
+  </p>
+  <h3>
+    Parameters
+  </h3>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Required
+          </th>
+          <th>
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            id
+          </td>
+          <td>
+            <a href="/documentation/rest/types#int">Integer</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            Uniquely identifies this outgoing webhook message; can be used for idempotency when processing the messages.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            type
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The webhook message type (see above list).
+          </td>
+        </tr>
+        <tr>
+          <td>
+            created_on
+          </td>
+          <td>
+            <a href="/documentation/rest/types#datetime">Date</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The date/time when the incident changed state.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            data
+          </td>
+          <td>
+            <a href="/documentation/rest/types#string">String</a>
+          </td>
+          <td>
+            Yes
+          </td>
+          <td>
+            The incident details at the time of the state change. Incident details are formatted similarly to the results of the Incident API.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <p>
+    NOTE: Outgoing messages are sent in an array. It is possible that multiple outgoing messages will be batched together and sent all at once from PagerDuty in a single outgoing webhook.
+  </p>
+  <h4>
+    Sample Outbound Webhook Incident Payload (both a <code>trigger</code> and a <code>resolve</code> at once)
+  </h4>
+  <div class="response">
+    <pre>
+<code class="language-javascript prettyprint linenums">{
+  "messages": [
+    {
+      "id": "bb8b8fe0-e8d5-11e2-9c1e-22000afd16cf",
+      "created_on": "2013-07-09T20:25:44Z",
+      "type": "incident.trigger",
+      "data": {
+        "incident": {
+          "id": "PIJ90N7",
+          "incident_number": 1,
+          "created_on": "2013-07-09T20:25:44Z",
+          "status": "triggered",
+          "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
+          "incident_key": "null",
+          "service": {
+            "id": "PBAZLIU",
+            "name": "service",
+            "html_url": "https://acme.pagerduty.com/services/PBAZLIU"
+          },
+          "assigned_to_user": {
+            "id": "PPI9KUT",
+            "name": "Alan Kay",
+            "email": "alan@pagerduty.com",
+            "html_url": "https://acme.pagerduty.com/users/PPI9KUT"
+          },
+          "trigger_summary_data": {
+            "subject": "45645"
+          },
+          "trigger_details_html_url": "https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7",
+          "last_status_change_on": "2013-07-09T20:25:44Z",
+          "last_status_change_by": "null"
+        }
+      }
+    },
+    {
+      "id": "8a1d6420-e9c4-11e2-b33e-f23c91699516",
+      "created_on": "2013-07-09T20:25:45Z",
+      "type": "incident.resolve",
+      "data": {
+        "incident": {
+          "id": "PIJ90N7",
+          "incident_number": 1,
+          "created_on": "2013-07-09T20:25:44Z",
+          "status": "resolved",
+          "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
+          "incident_key": "null",
+          "service": {
+            "id": "PBAZLIU",
+            "name": "service",
+            "html_url": "https://acme.pagerduty.com/services/PBAZLIU"
+          },
+          "assigned_to_user": "null",
+          "resolved_by_user": {
+            "id": "PPI9KUT",
+            "name": "Alan Kay",
+            "email": "alan@pagerduty.com",
+            "html_url": "https://acme.pagerduty.com/users/PPI9KUT"
+          },
+          "trigger_summary_data": {
+            "subject": "45645"
+          },
+          "trigger_details_html_url": "https://acme.pagerduty.com/incidents/PIJ90N7/log_entries/PIJ90N7",
+          "last_status_change_on": "2013-07-09T20:25:45Z",
+          "last_status_change_by": {
+            "id": "PPI9KUT",
+            "name": "Alan Kay",
+            "email": "alan@pagerduty.com",
+            "html_url": "https://acme.pagerduty.com/users/PPI9KUT"
+          }
+        }
+      }
+    }
+  ]
+}</code>
+</pre>
+  </div>
+  <h4>
+    Troubleshooting
+  </h4>
+  <p>
+    If you have any issues debugging your webhooks, you can use <a href="http://requestb.in/">RequestBin</a> to debug them.
+  </p>
 </div>


### PR DESCRIPTION
Use HTML tidy to clean up and reformat source HTML.
Also fixes some bugs that were exposed or made more obvious by the tidying.

Correctness verified by some basic `diff`ing of the resulting `public` directories built between this and `master` as well as visual inspection in the development environment.

The resulting diff ain't pretty to look at no matter how you slice it, but I'd recommend [a unified diff with whitespace ignored](https://github.com/PagerDuty/devdocs/pull/8/files?diff=unified&w=1).

Dirty details:
The tricky bit is that HTML Tidy doesn't know about the YAML in these files, so it will clobber it and break the Jekyll configuration.
To avoid this, we take a multi-step approach:

- `find source/documentation/ -type f -name "*.html" -exec perl -0777 -pi -e 's/---.*---\n/\n/igs' {} \;`
  - strip all YAML out of these files and replace it with a newline
- `git commit -a`
  - commit the result
- `git format-patch -U0 HEAD^ --stdout > /path/to/patch.patch`
  - create a patch that represents the change we just made (removing YAML). Crucially, include 0 lines of context in the diff as the lines around the YAML will change and this will cause merge conflicts with any context we have.
- `find source/documentation/ -type f -name "*.html" -exec tidy -q -config .tidy-config {} \;`
  - run HTML Tidy on all of the HTML files. Since no YAML exists in these files any longer, all we process is the HTML.
- `git commit -a`
  - commit the result
- `patch -R -p1 < /path/to/patch.patch`
  - apply the patch we created earlier in reverse, effectively re-adding all of the YAML
- `git reset --soft HEAD~2`
  - rewind two commits so we're left with the final result and not the intermediate commits
- `git commit -a`
  - commit the final result (this commit)