### PR TITLE
Re-add "pending actions" field documentation.

### DIFF
--- a/source/documentation/rest/incidents/list.html
+++ b/source/documentation/rest/incidents/list.html
@@ -314,6 +314,43 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
         </tr>
         <tr>
           <td>
+            pending_actions
+          </td>
+          <td>
+            <a href="/documentation/rest/types#array">Array</a>
+          </td>
+          <td>
+            <p>
+              The list of <code>pending_actions</code> on the incident. A <code>pending_actions</code> is an array containing all the pending_action objects for the incident at the current time. This list is empty if the status of the incident is <code>resolved</code>.
+            </p>
+            <p>
+              A pending_action object contains a <code>type</code> of action. <code>type</code> can be <code>escalate</code>, <code>unacknowledge</code> or <code>resolve</code>. A pending_action object contains <code>at</code>, the time at which the action will take place.
+            </p>
+            <p>
+              Example: <code>pending_actions</code> field for an incident.
+            </p>
+            <pre>
+<code class="language-javascript prettyprint linenums">{
+  "pending_actions": [
+    {
+      "type": "escalate",
+      "at": "2014-01-01T08:00:00Z"
+    },
+    {
+      "type": "unacknowledge",
+      "at": "2014-01-01T10:00:00Z"
+    },
+    {
+      "type": "resolve",
+      "at": "2014-01-01T11:00:00Z"
+    }
+  ]
+}</code>
+</pre>
+          </td>
+        </tr>
+        <tr>
+          <td>
             created_on
           </td>
           <td>

--- a/source/documentation/rest/incidents/list.html
+++ b/source/documentation/rest/incidents/list.html
@@ -577,6 +577,12 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
       "status": "triggered",
       "html_url": "https://acme.pagerduty.com/incidents/P2A6J96",
       "incident_key": null,
+      "pending_actions": [
+        {
+          "type": "escalate",
+          "at": "2012-09-11T22:59:21Z"
+        }
+      ],
       "service": {
         "id": "PBF77WY",
         "name": "Generic Api",
@@ -613,6 +619,12 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
       "status": "acknowledged",
       "html_url": "https://acme.pagerduty.com/incidents/PBXG6JS",
       "incident_key": "=?UTF-8?B?SnVzdCBhbiBlbWFpbCBmcm9tIOWvjOWjq+WxsSBhbmQg8J2EnvCdlaXwnZ+2IPCggoo=?=",
+      "pending_actions": [
+        {
+          "type": "unacknowledge",
+          "at": "2012-09-12T00:25:49Z"
+        }
+      ],
       "service": {
         "id": "PFRV88L",
         "name": "Generic Email",

--- a/source/documentation/rest/incidents/show.html
+++ b/source/documentation/rest/incidents/show.html
@@ -54,6 +54,20 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
   "incident_number": 1,
   "created_on": "2012-12-22T00:35:21Z",
   "status": "triggered",
+  "pending_actions": [
+    {
+      "type": "escalate",
+      "at": "2014-01-01T08:00:00Z"
+    },
+    {
+      "type": "unacknowledge",
+      "at": "2014-01-01T10:00:00Z"
+    },
+    {
+      "type": "resolve",
+      "at": "2014-01-01T11:00:00Z"
+    }
+  ],
   "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
   "incident_key": null,
   "service": {
@@ -105,6 +119,20 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
   "incident_number": 1,
   "created_on": "2012-12-22T00:35:21Z",
   "status": "triggered",
+  "pending_actions": [
+    {
+      "type": "escalate",
+      "at": "2014-01-01T08:00:00Z"
+    },
+    {
+      "type": "unacknowledge",
+      "at": "2014-01-01T08:00:00Z"
+    },
+    {
+      "type": "resolve",
+      "at": "2014-01-01T08:00:00Z"
+    }
+  ],
   "html_url": "https://acme.pagerduty.com/incidents/PIJ90N7",
   "incident_key": null,
   "service": {


### PR DESCRIPTION
The `pending_actions` field on `incidents` is now live - this PR re-adds the documentation for that field.