### PR TITLE
Added "alt" to the image context information table

### DIFF
--- a/source/documentation/integration/events/trigger.html
+++ b/source/documentation/integration/events/trigger.html
@@ -281,6 +281,17 @@ layout: main
             Optional link for the image.
           </td>
         </tr>
+        <tr>
+          <td>
+            alt
+          </td>
+          <td>
+            No
+          </td>
+          <td>
+            Optional alternative text for the image.
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
I said the wrong thing in the commit message. I added usage information for "alt" to the image context table.