### PR TITLE
Removed the deprecated type from Service API

### DIFF
--- a/source/documentation/rest/services/create.html
+++ b/source/documentation/rest/services/create.html
@@ -94,7 +94,7 @@ POST https://<span class="base_url contenteditable persist" contenteditable="tru
             Yes
           </td>
           <td>
-            The type of service to create. Can be one of <code>generic_email</code>, <code>generic_events_api</code>, <code>keynote</code>, <code>nagios</code>, <code>pingdom</code>, <code>server_density</code> or <code>sql_monitor</code>.
+            The type of service to create. Can be one of <code>generic_email</code>, <code>generic_events_api</code>, <code>keynote</code>, <code>nagios</code>, <code>pingdom</code> or <code>sql_monitor</code>.
           </td>
         </tr>
         <tr>
@@ -272,7 +272,7 @@ POST https://<span class="base_url contenteditable persist" contenteditable="tru
   </h3>
   <pre>
 <code class="prettyprint language-bash curl">curl -H "Content-type: application/json" -H "Authorization: Token token=<span class="base_auth_token contenteditable persist" contenteditable="true">E7px6VVr3PVHZPJq51oa</span>" -X POST \
-    -d '{    
+    -d '{
       "service": {
         "name": "<span class='curl_params-name contenteditable' contenteditable='true'>default-email</span>",
         "description": "<span class='curl_params-description contenteditable' contenteditable='true'>default email service</span>",


### PR DESCRIPTION
This deprecates the use of Server Density as `type` argument in the create service api. 

