### PR TITLE
Update events API guide to reflect service -> integration

### DIFF
--- a/source/documentation/howto/manually-trigger-an-incident.md
+++ b/source/documentation/howto/manually-trigger-an-incident.md
@@ -10,7 +10,7 @@ permalink: /documentation/howto/manually-trigger-an-incident/
   Triggering an incident manually within PagerDuty can happen several ways: through the dashboard, via email, or via our API. The first two methods are covered extensively in our <a href="https://support.pagerduty.com/hc/en-us/articles/202829230-How-to-Trigger-an-Incident-Through-the-Dashboard-Email-Or-The-API">support documentation</a>, so we'll go over using the incident API.
 </p>
 <p>
-  To trigger an incident via the API, you'll need a service key. You can find this information on the Services page or via a service's settings. The following code sample will use PDJS, but you can trigger incidents via any library or language that can work with HTTP and JSON.
+  To trigger an incident via the API, you'll need an integration key. You can find this information on the Services page or via a service's settings. The following code sample will use PDJS, but you can trigger incidents via any library or language that can work with HTTP and JSON.
 </p>
 
 <pre>
@@ -59,4 +59,4 @@ trigger = function () {
 <p>The <strong>incident_key</strong> field may be any string, but it's a good idea to randomize this as much as possible.</p>
 <p>Submitting multiple incidents for the same <strong>incident_key</strong> will result in the incident being triggered again. This event will be attached to the existing incident with this key and will alert via the service's escalation policy. Using an <strong>incident_key</strong> from a closed incident will result in a new incident being created.</p>
 
-<p>To play with sample code, you can enter a service key on <a href="http://jsfiddle.net/PagerDuty/azh132ch/8/">JSFiddle</a> to manually trigger an incident. Open your browser's JavaScript console to view the API's response.</p>
+<p>To play with sample code, you can enter an integration key on <a href="http://jsfiddle.net/PagerDuty/azh132ch/8/">JSFiddle</a> to manually trigger an incident. Open your browser's JavaScript console to view the API's response.</p>

--- a/source/documentation/integration/events/acknowledge.html
+++ b/source/documentation/integration/events/acknowledge.html
@@ -58,7 +58,7 @@ layout: main
             Yes
           </td>
           <td>
-            The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.
+            The GUID of one of your "Generic API" integrations. This is the "integration key" listed on a service's "Integrations" page.
           </td>
         </tr>
         <tr>

--- a/source/documentation/integration/events/index.html
+++ b/source/documentation/integration/events/index.html
@@ -30,7 +30,7 @@ redirect_from:
     The API was designed to allow you to easily integrate a monitoring system with a Service in PagerDuty. Monitoring systems generally send out events when problems are detected and when these problems have been resolved (fixed). Some more advanced systems also understand the concept of acknowledgements: problems can be acknowledged by an engineer to signal he or she is working on fixing the issue.
   </p>
   <p>
-    Since monitoring systems emit events, the API is based around accepting events. Incoming events (sent via the API) are routed to a PagerDuty service and processed. They may result in a new incident being created, or an existing incident being acknowledged or resolved.
+    Since monitoring systems emit events, the API is based around accepting events. Incoming events (sent via the API) are routed to a PagerDuty service via an API Integration and processed. They may result in a new incident being created, or an existing incident being acknowledged or resolved.
   </p>
   <p>
     The same event-based API can also be used to integrate a PagerDuty service with ticketing systems and various other software tools.
@@ -42,18 +42,11 @@ redirect_from:
     Getting Started
   </h2>
   <p>
-    The event integration API can be used with any "Generic API" service in PagerDuty. If you don't already have a "Generic API" service, you should create one:
+    The event integration API can be used with any "Generic API" integration in PagerDuty. If you don't already have a service with a "Generic API" integration, you should create one by <a href="https://support.pagerduty.com/hc/en-us/articles/202830340-Creating-a-Generic-API-Integration">following the steps in our "Creating a Generic API Integration" guide.</a>
   </p>
-  <ol>
-    <li>In your account, under the Services tab, click "Add New Service".
-    </li>
-    <li>Enter a name for the service and select an escalation policy. Then, select "Generic API" for the Service Type.
-    </li>
-    <li>Click the "Add Service" button.
-    </li>
-    <li>Once the service is created, you'll be taken to the service page. On this page, you'll see the "Service key", which is needed to access the API
-    </li>
-  </ol>
+  <p>
+    Once the integration has been created, make a note of its "Integration Key". You'll use this value, which is unique to the integration, as the <code>service_key</code> that's submitted to the Events API.
+  </p>
   <h2>
     Making a Request
   </h2>

--- a/source/documentation/integration/events/resolve.html
+++ b/source/documentation/integration/events/resolve.html
@@ -58,7 +58,7 @@ layout: main
             Yes
           </td>
           <td>
-            The GUID of one of your "Events API" services. This is the "service key" listed on a Generic API's service detail page.
+            The GUID of one of your "Generic API" integrations. This is the "integration key" listed on a service's "Integrations" page.
           </td>
         </tr>
         <tr>

--- a/source/documentation/integration/events/trigger.html
+++ b/source/documentation/integration/events/trigger.html
@@ -58,7 +58,7 @@ layout: main
             Yes
           </td>
           <td>
-            The GUID of one of your "Generic API" services. This is the "service key" listed on a Generic API's service detail page.
+            The GUID of one of your "Generic API" integrations. This is the "integration key" listed on a service's "Integrations" page.
           </td>
         </tr>
         <tr>

--- a/source/documentation/rest/log_entries/show.html
+++ b/source/documentation/rest/log_entries/show.html
@@ -513,7 +513,7 @@ GET https://<span class="base_url contenteditable persist" contenteditable="true
                 <a href="/documentation/rest/types#string">String</a>
               </td>
               <td>
-                API service key
+                Generic API integration/service key
               </td>
             </tr>
             <tr>

--- a/source/documentation/rest/services/index.html
+++ b/source/documentation/rest/services/index.html
@@ -98,7 +98,7 @@ layout: main
           <a href="/documentation/rest/services/regenerate_key">POST services/:id/regenerate_key</a>
         </td>
         <td>
-          Regenerate a new service key for an existing service.
+          Regenerate a new integration/service key for an existing service.
         </td>
       </tr>
     </tbody>

--- a/source/documentation/rest/services/regenerate_key.html
+++ b/source/documentation/rest/services/regenerate_key.html
@@ -26,7 +26,7 @@ layout: main
     POST services/:id/regenerate_key
   </h1>
   <p>
-    Regenerate a new service key for an existing service.
+    Regenerate a new integration/service key for an existing service.
   </p>
   <h3>
     Resource URL

--- a/source/documentation/rest/services/update.html
+++ b/source/documentation/rest/services/update.html
@@ -205,7 +205,7 @@ PUT https://<span class="base_url contenteditable persist" contenteditable="true
           </td>
           <td>
             <p>
-              The service key for the service.
+              The integration/service key for the service.
             </p>
             <p>
               Do not specify the domain. e.g. <code>my-service</code> rather than <code>my-service@my-subdomain.pagerduty.com</code>


### PR DESCRIPTION
- link to support guide on creating an API integration
- update terminology to be "integration" instead of "service" where appropriate