### PR TITLE
Update REST API v1 deprecation language for EOL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.0.0'
+ruby '~> 2.0'
 gem 'jekyll', '~> 2.0'
 gem 'jekyll-redirect-from'
 gem 'jekyll-sitemap'

--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -24,8 +24,8 @@
     <div id='deprecation-warning'>
       <div class='alert-warning alert alert-block'>
         <p>
-          <strong>PagerDuty API v1 is deprecated.</strong>
-          Learn about <a href='https://v2.developer.pagerduty.com/docs/migrating-to-api-v2' target='v2'>migrating to API v2</a>, read the <a href='https://v2.developer.pagerduty.com/v2/docs/api-v2-frequently-asked-questions' target='v2'>API v1 End-of-Life FAQ</a>, or <a href='mailto:support@pagerduty.com'>contact our support team</a> for assistance.
+          <strong>REST API v1 is end-of-life.</strong>
+          Learn about <a href='https://v2.developer.pagerduty.com/docs/migrating-to-api-v2' target='v2'>migrating to v2</a>, read the <a href='https://v2.developer.pagerduty.com/v2/docs/api-v2-frequently-asked-questions' target='v2'>REST API v2 Introduction FAQ</a>, or <a href='mailto:support@pagerduty.com'>contact our support team</a> for assistance.
         </p>
       </div>
     </div>

--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -33,7 +33,7 @@
                 <div class='col9 main-header'>
                   <!-- <h2>Documentation</h2> -->
                   {% if page.path != 'index.html' %}
-                    <h2><a href="https://v2.developer.pagerduty.com" id="learn-about-v2" class="pgd-button top-nav">Learn About API v2.0</a></h2>
+                    <h2><a href="https://v2.developer.pagerduty.com/docs/migrating-to-api-v2" id="learn-about-v2" class="pgd-button top-nav">Migrate to REST API v2</a></h2>
                   {% endif %}
                 </div>
               </div>

--- a/source/assets/css/application.css
+++ b/source/assets/css/application.css
@@ -2009,11 +2009,15 @@ a.pgd-button:hover, a.pgd-button:active  {
     border: 0 none;
     -webkit-border-radius: 0;
     border-radius: 0;
-    border-top: 1px solid #eecc62;
+    border-top: 1px solid #FD9E8E;
     padding: 10px;
+	background-color: #FC8B8D;
 }
 #deprecation-warning .alert p {
     text-align: center;
+}
+#deprecation-warning .alert a {
+    color: #FFF4CB;
 }
 
 @media (max-width: 1500px) {

--- a/source/index.html
+++ b/source/index.html
@@ -9,7 +9,7 @@ layout: index
                   <div class='landing'>                    
                     <div class='section'>
                       <h3>Want to build something without coding?</h3>
-                      With <a href="https://zapier.com/">Zapier</a> and <a href="https://support.pagerduty.com/hc/en-us/articles/202829320">PagerDuty webhooks</a>, you can automate workflow with hundreds of apps.
+                      With <a href="https://zapier.com/">Zapier</a> and <a href="https://support.pagerduty.com/docs/webhooks">PagerDuty webhooks</a>, you can automate workflow with hundreds of apps.
                     </div>
                     <div class='section'>
                       <h3>Looking for existing integration guides?</h3>

--- a/source/index.html
+++ b/source/index.html
@@ -3,8 +3,8 @@ title: PagerDuty Developer - Home
 layout: index
 ---
 <div class="api-v20-hero">
-    <h1>Announcing PagerDuty API v2.0</h1>
-    <a href="https://v2.developer.pagerduty.com" class="pgd-button">Learn More</a>
+    <h1>Migrate to PagerDuty REST API v2</h1>
+    <a href="https://v2.developer.pagerduty.com/docs/migrating-to-api-v2" class="pgd-button">Learn More</a>
 </div>
                   <div class='landing'>                    
                     <div class='section'>


### PR DESCRIPTION
This PR:

- Changes the warning banner to note the REST API v1 is no longer deprecated, but actually end-of-life
- Fixes a bad KB link for webhooks